### PR TITLE
Only search text inside Body tag

### DIFF
--- a/filter.js
+++ b/filter.js
@@ -33,13 +33,13 @@ function generateProfanityList() {
 // Remove the profanity from the document
 function removeProfanity() {
   var evalResult = document.evaluate(
-    './/text()[normalize-space(.) != ""]',
+    '//body//text()[normalize-space(.) != ""]',
     document,
     null,
     XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
     null
   );
-  
+
   for (var i = 0; i < evalResult.snapshotLength; i++) {
     var textNode = evalResult.snapshotItem(i);
     for (var z = 0; z < profanityList.length; z++) {
@@ -51,7 +51,7 @@ function removeProfanity() {
 // Remove the profanity from the node
 function removeProfanityFromNode(event) {
   var node = event.target;
-  
+
   var evalResult = document.evaluate(
     './/text()[normalize-space(.) != ""]',
     node,
@@ -59,7 +59,7 @@ function removeProfanityFromNode(event) {
     XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
     null
   );
-  
+
   for (var i = 0; i < evalResult.snapshotLength; i++) {
     var textNode = evalResult.snapshotItem(i);
     for (var z = 0; z < profanityList.length; z++) {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Profanity Filter",
   "author": "phermium",
   "manifest_version": 2,
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "An advanced profanity filter.",
   "icons": {
     "16": "icons/icon16.png",

--- a/options.js
+++ b/options.js
@@ -5,7 +5,7 @@ function save_options() {
   settings.wordList = document.getElementById('wordList').value;
   settings.preserveFirst = document.getElementById('preserveFirst').checked;
   settings.filterSubstring = document.getElementById('filterSubstring').checked;
-  settings.showCounter = document.getElementById('showCounter').checked
+  settings.showCounter = document.getElementById('showCounter').checked;
 
   // Save settings
   chrome.storage.sync.set(settings, function() {
@@ -49,11 +49,11 @@ function toggleProfanity() {
     profanityList.style.display = 'block';
     document.getElementById('listWarning').style.display = 'none';
     document.getElementById('wordList').focus();
-    document.getElementById('toggleProfanity').textContent = "Hide Profanity List"
+    document.getElementById('toggleProfanity').textContent = "Hide Profanity List";
   } else {
     profanityList.style.display = 'none';
     document.getElementById('listWarning').style.display = 'block';
-    document.getElementById('toggleProfanity').textContent = "Modify Profanity List"
+    document.getElementById('toggleProfanity').textContent = "Modify Profanity List";
   }
 }
 


### PR DESCRIPTION
Previously we were searching the entire document for matched words, but we were bumping into encoded text in `css` that was breaking things. I adjusted this to only search text inside the `<body>` tag. While this should not have any negative effects, this might need more testing/validation.