### PR TITLE
Migrate wordlist

### DIFF
--- a/eventPage.js
+++ b/eventPage.js
@@ -8,6 +8,9 @@ chrome.runtime.onInstalled.addListener(function(details){
   } else if (details.reason == "update") {
     // var thisVersion = chrome.runtime.getManifest().version;
     // console.log("Updated from " + details.previousVersion + " to " + thisVersion + "!");
+
+    // TODO: Migrate wordList - Open options page to show new features
+    chrome.runtime.openOptionsPage();
   }
 });
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Profanity Filter",
   "author": "phermium",
   "manifest_version": 2,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Hide offensive words on the webpages you visit",
   "icons": {
     "16": "icons/icon16.png",

--- a/options.js
+++ b/options.js
@@ -138,6 +138,41 @@ function importConfig(event) {
   }
 }
 
+// TODO: Migrate wordList to new words object
+function migrateWordList() {
+  chrome.storage.sync.get('wordList', function(storage) {
+    var wordListStr = storage.wordList;
+
+    if (wordListStr != undefined && wordListStr != '') {
+      var word = '';
+      var wordList = wordListStr.split(',');
+
+      try {
+        // Migrate to new words object
+        for (i = 0; i < wordList.length; i++) {
+          word = wordList[i];
+          if (word != "") {
+            if (!arrayContains(Object.keys(config.words), word)) {
+              console.log('Migrating word: ' + word);
+              config.words[word] = {"matchMethod": 1, "words": []};
+            } else {
+              console.log('Word already in list: ' + word);
+            }
+          }
+        }
+
+        // Remove wordList if successful
+        console.log(wordListStr, wordList);
+        saveOptions(undefined, config);
+        chrome.storage.sync.remove('wordList');
+      }
+      catch(error) {
+        console.log('Error: Aborting wordList migration!', error);
+      }
+    }
+  });
+}
+
 // Switching Tabs
 function openTab(event) {
   // Don't run on current tab
@@ -162,6 +197,7 @@ function openTab(event) {
 function populateOptions() {
   chrome.storage.sync.get(defaults, function(settings) {
     config = settings; // Make config globally available
+    migrateWordList(); // TODO: Migrate wordList
 
     // Show/hide censor options and word substitutions based on filter method
     dynamicList(filterMethods, 'filterMethodSelect');

--- a/options.js
+++ b/options.js
@@ -118,6 +118,11 @@ function exportConfig() {
   });
 }
 
+function filterMethodSelect(event) {
+  config.filterMethod = document.getElementById('filterMethodSelect').selectedIndex;
+  saveOptions(event, config);
+}
+
 function globalMatchMethod(event) {
   var selectedIndex = document.getElementById('globalMatchMethodSelect').selectedIndex;
   config.globalMatchMethod = selectedIndex;
@@ -131,11 +136,6 @@ function importConfig(event) {
   } catch (e) {
     updateStatus('Settings not saved! Please try again.', true, 5000);
   }
-}
-
-function filterMethodSelect(event) {
-  config.filterMethod = document.getElementById('filterMethodSelect').selectedIndex;
-  saveOptions(event, config);
 }
 
 // Switching Tabs


### PR DESCRIPTION
* Automatically migrate to the new version of wordlist. 
* This will automatically open the settings page on extension upgrade. The main reason for this is to facilitate upgrading the wordList CSV to the new words object.