### PR TITLE
Censor: Preserve last character

### DIFF
--- a/filter.js
+++ b/filter.js
@@ -36,25 +36,25 @@ var xpathNodeText = './/*[not(self::script or self::style)]/text()[normalize-spa
 // Word must match exactly (not sub-string)
 // /\b(w)ord\b/gi
 function buildExactRegexp(word) {
-  wordRegExps.push(new RegExp('\\b(' + word[0] + ')' + word.substring(1)+ '\\b', 'gi' ));
+  wordRegExps.push(new RegExp('\\b(' + word[0] + ')' + word.slice(1)+ '\\b', 'gi' ));
 }
 
 // Match any part of a word (sub-string)
 // /(w)ord/gi
 function buildPartRegexp(word) {
-  wordRegExps.push(new RegExp('(' + word[0] + ')' + word.substring(1), 'gi' ));
+  wordRegExps.push(new RegExp('(' + word[0] + ')' + word.slice(1), 'gi' ));
 }
 
 // Match entire word that contains sub-string
 // /\b[\w-]*(w)ord[\w-]*\b/gi
 function buildWholeRegexp(word) {
-  wordRegExps.push(new RegExp('\\b([\\w-]*' + word[0] + ')' + word.substring(1) + '[\\w-]*\\b', 'gi' ));
+  wordRegExps.push(new RegExp('\\b([\\w-]*' + word[0] + ')' + word.slice(1) + '[\\w-]*\\b', 'gi' ))
 }
 
 // Match entire word that contains sub-string and surrounding whitespace
 // /\s?\b[\w-]*(w)ord[\w-]*\b\s?/gi
 function buildWholeRegexpForRemove(word) {
-  wordRegExps.push(new RegExp('\\s?\\b([\\w-]*' + word[0] + ')' + word.substring(1) + '[\\w-]*\\b\\s?', 'gi' ));
+  wordRegExps.push(new RegExp('\\s?\\b([\\w-]*' + word[0] + ')' + word.slice(1) + '[\\w-]*\\b\\s?', 'gi' ));
 }
 
 function checkNodeForProfanity(mutation) {
@@ -82,9 +82,9 @@ function censorReplace(strMatchingString, strFirstLetter) {
     }
   } else {
     if (preserveFirst && preserveLast) {
-      censoredString = strFirstLetter + censorCharacter.repeat((strMatchingString.length - 2)) + strMatchingString.slice(-1); // done
+      censoredString = strFirstLetter + censorCharacter.repeat((strMatchingString.length - 2)) + strMatchingString.slice(-1);
     } else if (preserveFirst) {
-      censoredString = strFirstLetter + censorCharacter.repeat((strMatchingString.length - 1)); // done
+      censoredString = strFirstLetter + censorCharacter.repeat((strMatchingString.length - 1));
     } else if (preserveLast) {
       censoredString = censorCharacter.repeat((strMatchingString.length - 1)) + strMatchingString.slice(-1);
     } else {

--- a/filter.js
+++ b/filter.js
@@ -72,9 +72,9 @@ function censorReplace(strMatchingString, strFirstLetter) {
 
   if (censorFixedLength > 0) {
     if (preserveFirst && preserveLast) {
-      censoredString = strFirstLetter[0] + censorCharacter.repeat((censorFixedLength - 2)) + strMatchingString.slice(-1);
+      censoredString = strFirstLetter + censorCharacter.repeat((censorFixedLength - 2)) + strMatchingString.slice(-1);
     } else if (preserveFirst) {
-      censoredString = strFirstLetter[0] + censorCharacter.repeat((censorFixedLength - 1));
+      censoredString = strFirstLetter + censorCharacter.repeat((censorFixedLength - 1));
     } else if (preserveLast) {
       censoredString = censorCharacter.repeat((censorFixedLength - 1)) + strMatchingString.slice(-1);
     } else {
@@ -82,9 +82,9 @@ function censorReplace(strMatchingString, strFirstLetter) {
     }
   } else {
     if (preserveFirst && preserveLast) {
-      censoredString = strFirstLetter[0] + censorCharacter.repeat((strMatchingString.length - 2)) + strMatchingString.slice(-1); // done
+      censoredString = strFirstLetter + censorCharacter.repeat((strMatchingString.length - 2)) + strMatchingString.slice(-1); // done
     } else if (preserveFirst) {
-      censoredString = strFirstLetter[0] + censorCharacter.repeat((strMatchingString.length - 1)); // done
+      censoredString = strFirstLetter + censorCharacter.repeat((strMatchingString.length - 1)); // done
     } else if (preserveLast) {
       censoredString = censorCharacter.repeat((strMatchingString.length - 1)) + strMatchingString.slice(-1);
     } else {

--- a/filter.js
+++ b/filter.js
@@ -88,7 +88,7 @@ function censorReplace(strMatchingString, strFirstLetter) {
     } else if (preserveLast) {
       censoredString = censorCharacter.repeat((strMatchingString.length - 1)) + strMatchingString.slice(-1);
     } else {
-      censoredString = censorCharacter.repeat(strMatchingString.length); // done
+      censoredString = censorCharacter.repeat(strMatchingString.length);
     }
   }
 

--- a/filter.js
+++ b/filter.js
@@ -7,6 +7,7 @@ var defaults = {
   "filterMethod": 0, // ["Censor", "Substitute", "Remove"];
   "globalMatchMethod": 3, // ["Exact", "Partial", "Whole", "Per-Word"]
   "preserveFirst": false,
+  "preserveLast": false,
   "showCounter": true,
   "substitutionMark": true,
   "words": {}
@@ -26,7 +27,7 @@ var defaultWords = {
   "tits": {"matchMethod": 1, "words": ["explative"] },
   "whore": {"matchMethod": 1, "words": ["harlot", "tramp"] }
 };
-var censorCharacter, censorFixedLength, defaultSubstitutions, disabledDomains, filterMethod, globalMatchMethod, matchMethod, preserveFirst, showCounter, substitutionMark, words, wordList;
+var censorCharacter, censorFixedLength, defaultSubstitutions, disabledDomains, filterMethod, globalMatchMethod, matchMethod, preserveFirst, preserveLast, showCounter, substitutionMark, words, wordList;
 var wordRegExps = [];
 var whitespaceRegExp = new RegExp('\\s');
 var xpathDocText = '//*[not(self::script or self::style)]/text()[normalize-space(.) != ""]';
@@ -35,7 +36,7 @@ var xpathNodeText = './/*[not(self::script or self::style)]/text()[normalize-spa
 // Word must match exactly (not sub-string)
 // /\b(w)ord\b/gi
 function buildExactRegexp(word) {
-  wordRegExps.push(new RegExp('\\b(' + word[0] + ')' + word.substring(1) + '\\b', 'gi' ));
+  wordRegExps.push(new RegExp('\\b(' + word[0] + ')' + word.substring(1)+ '\\b', 'gi' ));
 }
 
 // Match any part of a word (sub-string)
@@ -70,16 +71,24 @@ function censorReplace(strMatchingString, strFirstLetter) {
   var censoredString = '';
 
   if (censorFixedLength > 0) {
-    if (preserveFirst) {
+    if (preserveFirst && preserveLast) {
+      censoredString = strFirstLetter[0] + censorCharacter.repeat((censorFixedLength - 2)) + strMatchingString.slice(-1);
+    } else if (preserveFirst) {
       censoredString = strFirstLetter[0] + censorCharacter.repeat((censorFixedLength - 1));
+    } else if (preserveLast) {
+      censoredString = censorCharacter.repeat((censorFixedLength - 1)) + strMatchingString.slice(-1);
     } else {
       censoredString = censorCharacter.repeat(censorFixedLength);
     }
   } else {
-    if (preserveFirst) {
-      censoredString = strFirstLetter[0] + censorCharacter.repeat((strMatchingString.length - 1));
+    if (preserveFirst && preserveLast) {
+      censoredString = strFirstLetter[0] + censorCharacter.repeat((strMatchingString.length - 2)) + strMatchingString.slice(-1); // done
+    } else if (preserveFirst) {
+      censoredString = strFirstLetter[0] + censorCharacter.repeat((strMatchingString.length - 1)); // done
+    } else if (preserveLast) {
+      censoredString = censorCharacter.repeat((strMatchingString.length - 1)) + strMatchingString.slice(-1);
     } else {
-      censoredString = censorCharacter.repeat(strMatchingString.length);
+      censoredString = censorCharacter.repeat(strMatchingString.length); // done
     }
   }
 
@@ -110,6 +119,7 @@ function cleanPage() {
     globalMatchMethod = storage.globalMatchMethod;
     matchMethod = storage.matchMethod;
     preserveFirst = storage.preserveFirst;
+    preserveLast = storage.preserveLast;
     showCounter = storage.showCounter;
     substitutionMark = storage.substitutionMark;
     words = storage.words;

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Profanity Filter",
   "author": "phermium",
   "manifest_version": 2,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Hide offensive words on the webpages you visit",
   "icons": {
     "16": "icons/icon16.png",

--- a/options.html
+++ b/options.html
@@ -32,6 +32,12 @@
     </label>
     <br />
     <label>
+      <input type="checkbox" id="preserveLast">
+      Preserve the last letter
+      <span class="notes">(Dog: dog = **g)</span>
+    </label>
+    <br />
+    <label>
       Censor character:
       <select id="censorCharacterSelect" class="small">
         <option value="*">*</option>

--- a/options.js
+++ b/options.js
@@ -339,7 +339,7 @@ function wordAdd(event) {
   var word = document.getElementById('wordText').value;
   if (word != "") {
     if (!arrayContains(Object.keys(config.words), word)) {
-      config.words[word] = {"matchMethod": 1, "words": []};
+      config.words[word] = {"matchMethod": 0, "words": []};
       saveOptions(event, config);
       document.getElementById('wordText').value = "";
     } else {

--- a/options.js
+++ b/options.js
@@ -7,6 +7,7 @@ var defaults = {
   "filterMethod": 0, // ["Censor", "Substitute", "Remove"];
   "globalMatchMethod": 3, // ["Exact", "Partial", "Whole", "Per-Word"]
   "preserveFirst": false,
+  "preserveLast": false,
   "showCounter": true,
   "substitutionMark": true,
   "words": {}
@@ -240,6 +241,7 @@ function populateOptions() {
     document.getElementById('censorFixedLengthSelect').selectedIndex = settings.censorFixedLength;
     document.getElementById('censorCharacterSelect').value = settings.censorCharacter;
     document.getElementById('preserveFirst').checked = settings.preserveFirst;
+    document.getElementById('preserveLast').checked = settings.preserveLast;
     document.getElementById('substitutionMark').checked = settings.substitutionMark;
     document.getElementById('showCounter').checked = settings.showCounter;
     dynamicList(matchMethods, 'globalMatchMethodSelect');
@@ -276,6 +278,7 @@ function saveOptions(event, settings) {
   if (settings === undefined) {
     settings = {};
     settings.preserveFirst = document.getElementById('preserveFirst').checked;
+    settings.preserveLast = document.getElementById('preserveLast').checked;
     settings.showCounter = document.getElementById('showCounter').checked;
     settings.substitutionMark = document.getElementById('substitutionMark').checked;
   }
@@ -379,6 +382,7 @@ window.addEventListener('load', populateOptions);
 document.getElementById('filterMethodSelect').addEventListener('change', filterMethodSelect);
 // Filter - Censor
 document.getElementById('preserveFirst').addEventListener('click', saveOptions);
+document.getElementById('preserveLast').addEventListener('click', saveOptions);
 document.getElementById('censorCharacterSelect').addEventListener('change', censorCharacter);
 document.getElementById('censorFixedLengthSelect').addEventListener('change', censorFixedLength);
 // Filter - Substitute

--- a/options.js
+++ b/options.js
@@ -264,10 +264,10 @@ function restoreDefaults() {
   exportConfig();
   chrome.storage.sync.clear(function(){
     if (chrome.runtime.lastError) {
-      updateStatus('Error restoring defaults! Please try again.', true, 5000);
+      updateStatus('Error restoring defaults!', true, 5000);
     } else {
       populateOptions();
-      updateStatus('Settings restored!', false, 3000);
+      updateStatus('Default settings restored!', false, 3000);
     }
   });
 }
@@ -288,7 +288,6 @@ function saveOptions(event, settings) {
     if (chrome.runtime.lastError) {
       updateStatus('Settings not saved! Please try again.', true, 5000);
     } else {
-      updateStatus('Settings saved successfully!', false, 3000);
       populateOptions();
     }
   });


### PR DESCRIPTION
- Censor Option: Preserve Last character of word. This can be combined with Preserve First to produce a result like `h***e` when filtering the word `house`
- Remove "Settings saved successfully" message (displayed too frequently)
- New words are added with the exact match method by default