### PR TITLE
Final changes before release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules/*
 
 # Combined file (prebuild.js)
 src/filter.bundle.ts
+
+# Filter for testing
+dist/filter.js

--- a/dist/config.js
+++ b/dist/config.js
@@ -18,6 +18,13 @@ export default class Config {
         for (let k in async_param)
             this[k] = async_param[k];
     }
+    addWord(str) {
+        if (!arrayContains(Object.keys(this.words), str)) {
+            this.words[str] = { matchMethod: this.defaultWordMatchMethod, repeat: this.defaultWordRepeat, words: [] };
+            return true;
+        }
+        return false;
+    }
     static build(keys) {
         return __awaiter(this, void 0, void 0, function* () {
             let async_result = yield Config.getConfig(keys);
@@ -111,6 +118,13 @@ export default class Config {
             });
         });
     }
+    sanitizeWords() {
+        let sanitizedWords = {};
+        Object.keys(this.words).sort().forEach((key) => {
+            sanitizedWords[key.trim().toLowerCase()] = this.words[key];
+        });
+        this.words = sanitizedWords;
+    }
     save() {
         var self = this;
         return new Promise(function (resolve, reject) {
@@ -141,14 +155,15 @@ export default class Config {
     }
 }
 Config._defaults = {
+    advancedDomains: [],
     censorCharacter: '*',
     censorFixedLength: 0,
-    advancedDomains: [],
     defaultSubstitutions: ['censored', 'expletive', 'filtered'],
+    defaultWordMatchMethod: 0,
+    defaultWordRepeat: false,
     disabledDomains: [],
     filterMethod: 0,
     globalMatchMethod: 3,
-    matchRepeated: true,
     password: null,
     preserveCase: true,
     preserveFirst: true,
@@ -157,22 +172,22 @@ Config._defaults = {
     substitutionMark: true
 };
 Config._defaultWords = {
-    'ass': { 'matchMethod': 0, 'words': ['butt', 'tail'] },
-    'asses': { 'matchMethod': 0, 'words': ['butts'] },
-    'asshole': { 'matchMethod': 1, 'words': ['butthole', 'jerk'] },
-    'bastard': { 'matchMethod': 1, 'words': ['imperfect', 'impure'] },
-    'bitch': { 'matchMethod': 1, 'words': ['jerk'] },
-    'cunt': { 'matchMethod': 1, 'words': ['explative'] },
-    'dammit': { 'matchMethod': 1, 'words': ['dangit'] },
-    'damn': { 'matchMethod': 1, 'words': ['dang', 'darn'] },
-    'dumbass': { 'matchMethod': 0, 'words': ['idiot'] },
-    'fuck': { 'matchMethod': 1, 'words': ['freak', 'fudge'] },
-    'piss': { 'matchMethod': 1, 'words': ['pee'] },
-    'pissed': { 'matchMethod': 0, 'words': ['ticked'] },
-    'slut': { 'matchMethod': 1, 'words': ['imperfect', 'impure'] },
-    'shit': { 'matchMethod': 1, 'words': ['crap', 'crud', 'poop'] },
-    'tits': { 'matchMethod': 1, 'words': ['explative'] },
-    'whore': { 'matchMethod': 1, 'words': ['harlot', 'tramp'] }
+    'ass': { matchMethod: 0, repeat: true, words: ['butt', 'tail'] },
+    'asses': { matchMethod: 0, repeat: true, words: ['butts'] },
+    'asshole': { matchMethod: 1, repeat: true, words: ['butthole', 'jerk'] },
+    'bastard': { matchMethod: 1, repeat: true, words: ['imperfect', 'impure'] },
+    'bitch': { matchMethod: 1, repeat: true, words: ['jerk'] },
+    'cunt': { matchMethod: 1, repeat: true, words: ['explative'] },
+    'dammit': { matchMethod: 1, repeat: true, words: ['dangit'] },
+    'damn': { matchMethod: 1, repeat: true, words: ['dang', 'darn'] },
+    'dumbass': { matchMethod: 0, repeat: true, words: ['idiot'] },
+    'fuck': { matchMethod: 1, repeat: true, words: ['freak', 'fudge'] },
+    'piss': { matchMethod: 1, repeat: true, words: ['pee'] },
+    'pissed': { matchMethod: 0, repeat: true, words: ['ticked'] },
+    'slut': { matchMethod: 1, repeat: true, words: ['imperfect', 'impure'] },
+    'shit': { matchMethod: 1, repeat: true, words: ['crap', 'crud', 'poop'] },
+    'tits': { matchMethod: 1, repeat: true, words: ['explative'] },
+    'whore': { matchMethod: 1, repeat: true, words: ['harlot', 'tramp'] }
 };
 Config._filterMethodNames = ['Censor', 'Substitute', 'Remove'];
 Config._matchMethodNames = ['Exact Match', 'Partial Match', 'Whole Match', 'Per-Word Match', 'Regular Expression'];

--- a/dist/domain.js
+++ b/dist/domain.js
@@ -6,12 +6,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+import { removeFromArray } from './helper.js';
 export default class Domain {
     static domainMatch(domain, domains) {
         let result = false;
         for (let x = 0; x < domains.length; x++) {
             if (domains[x]) {
-                let domainRegex = new RegExp('(^|\.)' + domains[x]);
+                let domainRegex = new RegExp('(^|\.)' + domains[x], 'i');
                 if (domainRegex.test(domain)) {
                     result = true;
                     break;
@@ -19,6 +20,19 @@ export default class Domain {
             }
         }
         return result;
+    }
+    // If a parent domain (example.com) is included, it will not +match all subdomains.
+    // If a subdomain is included, it will match itself and the parent, if present.
+    static removeFromList(domain, domains) {
+        let domainRegex;
+        let newDomainsList = domains;
+        for (let x = 0; x < domains.length; x++) {
+            domainRegex = new RegExp('(^|\.)' + domains[x], 'i');
+            if (domainRegex.test(domain)) {
+                newDomainsList = removeFromArray(newDomainsList, domains[x]);
+            }
+        }
+        return newDomainsList;
     }
     static getCurrentTab() {
         return new Promise(function (resolve, reject) {

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Profanity Filter",
   "author": "Richard Frost",
   "manifest_version": 2,
-  "version": "1.0.15",
+  "version": "1.1.0",
   "description": "Hide offensive words on the webpages you visit",
   "icons": {
     "16": "icons/icon16.png",
@@ -16,7 +16,9 @@
     "storage",
     "tabs"
   ],
-  "optional_permissions": [ "file://*/*" ],
+  "optional_permissions": [
+    "file://*/*"
+  ],
   "options_ui": {
     "page": "optionPage.html",
     "chrome_style": true
@@ -35,8 +37,12 @@
   },
   "content_scripts": [
     {
-      "matches": [ "<all_urls>" ],
-      "js": [ "filter.bundle.js" ],
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "filter.bundle.js"
+      ],
       "run_at": "document_start",
       "all_frames": true
     }

--- a/dist/optionPage.html
+++ b/dist/optionPage.html
@@ -172,24 +172,24 @@
   <h4>Advanced Domains</h4>
   <div class="notes">
     Only use when the filter isn't working for a page<br />
-    Warning: This option can have negative results
+    Warning: This option can have negative results - Use with caution.
   </div>
-  <select id="advancedDomainSelect"></select>
-  <button id="advancedDomainRemove">Remove</button>
+  <div id="advancedDomainNote" class="notes">Example: "google.com" or "mail.google.com"</div>
+  <input type="text" id="advancedDomainText" name="advancedDomainText" pattern="^[a-zA-Z0-9\.\-]+$">
+  <button id="advancedDomainAdd">Add</button>
   <div class="moveDown">
-    <div id="advancedDomainNote" class="notes">Example: "google.com" or "mail.google.com"</div>
-    <input type="text" id="advancedDomainText" name="advancedDomainText" pattern="^[a-zA-Z0-9\.\-]+$">
-    <button id="advancedDomainAdd">Add</button>
+    <select id="advancedDomainSelect"></select>
+    <button id="advancedDomainRemove">Remove</button>
   </div>
 
   <div class="moveDown"></div>
   <h4>Disabled Domains</h4>
-  <select id="domainSelect"></select>
-  <button id="domainRemove">Remove</button>
+  <div id="domainNote" class="notes">Example: "google.com" or "mail.google.com"</div>
+  <input type="text" id="domainText" name="domainText" pattern="^[a-zA-Z0-9\.\-]+$">
+  <button id="domainAdd">Add</button>
   <div class="moveDown">
-    <div id="domainNote" class="notes">Example: "google.com" or "mail.google.com"</div>
-    <input type="text" id="domainText" name="domainText" pattern="^[a-zA-Z0-9\.\-]+$">
-    <button id="domainAdd">Add</button>
+    <select id="domainSelect"></select>
+    <button id="domainRemove">Remove</button>
   </div>
 </div>
 

--- a/dist/page.js
+++ b/dist/page.js
@@ -1,4 +1,6 @@
 export default class Page {
+    // Returns true if a node should *not* be altered in any way
+    // Credit: https://github.com/ericwbailey/millennials-to-snake-people/blob/master/Source/content_script.js
     static isForbiddenNode(node) {
         return Boolean(node.isContentEditable || // DraftJS and many others
             (node.parentNode &&
@@ -16,8 +18,6 @@ export default class Page {
                     node.tagName == 'IFRAME')));
     }
 }
-// Returns true if a node should *not* be altered in any way
-// Credit: https://github.com/ericwbailey/millennials-to-snake-people/blob/master/Source/content_script.js
-Page.whitespaceRegExp = new RegExp('\\s');
+Page.forbiddenNodeRegExp = new RegExp('^\s*(<[a-z].+?\/?>|{.+?:.+?;.*}|https?:\/\/[^\s]+$)');
 Page.xpathDocText = '//*[not(self::script or self::style)]/text()[normalize-space(.) != \"\"]';
 Page.xpathNodeText = './/*[not(self::script or self::style)]/text()[normalize-space(.) != \"\"]';

--- a/dist/popup.css
+++ b/dist/popup.css
@@ -41,6 +41,10 @@ input:checked + .slider:before {
   transform: translateX(26px);
 }
 
+#advancedModeContainer {
+  text-align: center;
+}
+
 #banner {
   padding: 0px;
   margin: 0px;
@@ -68,7 +72,6 @@ input:checked + .slider:before {
 }
 
 #logo {
-  text-align: center;
   width: 64px;
   height: 64px;
   margin: 1rem;

--- a/dist/popup.html
+++ b/dist/popup.html
@@ -11,6 +11,12 @@
     </label>
   </div>
   <div class="divider"></div>
+  <div id="advancedModeContainer">
+    <label>
+      Advanced Mode:
+      <input class="unselectable" id="advancedMode" type="checkbox">
+    </label>
+  </div>
   <div id="filterMethodContainer">
     <div class="filter">
       <h4>Filter Method</h4>

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -6,13 +6,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { arrayContains, dynamicList, removeFromArray } from './helper.js';
+import { arrayContains, dynamicList } from './helper.js';
 import Config from './config.js';
 import Domain from './domain.js';
 class Popup {
     static load(instance) {
         return __awaiter(this, void 0, void 0, function* () {
-            instance.cfg = yield Config.build(['disabledDomains', 'filterMethod', 'password']);
+            instance.cfg = yield Config.build(['advancedDomains', 'disabledDomains', 'filterMethod', 'password']);
             instance.domain = new Domain();
             yield instance.domain.load();
             return instance;
@@ -32,6 +32,18 @@ class Popup {
         element.disabled = false;
         element.classList.remove('disabled');
     }
+    disableAdvancedMode(cfg, domain, key) {
+        return __awaiter(this, void 0, void 0, function* () {
+            let newDomainList = Domain.removeFromList(domain, cfg[key]);
+            if (newDomainList.length < cfg[key].length) {
+                cfg[key] = newDomainList;
+                let result = yield cfg.save();
+                if (!result) {
+                    chrome.tabs.reload();
+                }
+            }
+        });
+    }
     disableDomain() {
         return __awaiter(this, void 0, void 0, function* () {
             let popup = this;
@@ -39,29 +51,33 @@ class Popup {
                 popup.cfg.disabledDomains.push(popup.domain.hostname);
                 let result = yield popup.cfg.save();
                 if (!result) {
+                    Popup.disable(document.getElementById('advancedMode'));
                     Popup.disable(document.getElementById('filterMethodSelect'));
                     chrome.tabs.reload();
                 }
             }
         });
     }
-    // Remove all entries that disable the filter for domain
-    enableDomain() {
+    enableAdvancedMode(cfg, domain, key) {
         return __awaiter(this, void 0, void 0, function* () {
-            let popup = this;
-            let domainRegex, foundMatch;
-            let newDisabledDomains = popup.cfg.disabledDomains;
-            for (let x = 0; x < popup.cfg.disabledDomains.length; x++) {
-                domainRegex = new RegExp('(^|\.)' + popup.cfg.disabledDomains[x]);
-                if (domainRegex.test(popup.domain.hostname)) {
-                    foundMatch = true;
-                    newDisabledDomains = removeFromArray(newDisabledDomains, popup.cfg.disabledDomains[x]);
+            if (!arrayContains(cfg[key], domain)) {
+                cfg[key].push(domain);
+                let result = yield cfg.save();
+                if (!result) {
+                    chrome.tabs.reload();
                 }
             }
-            if (foundMatch) {
-                popup.cfg.disabledDomains = newDisabledDomains;
-                let result = yield popup.cfg.save();
+        });
+    }
+    // Remove all entries that disable the filter for domain
+    enableDomain(cfg, domain, key) {
+        return __awaiter(this, void 0, void 0, function* () {
+            let newDomainList = Domain.removeFromList(domain, cfg[key]);
+            if (newDomainList.length < cfg[key].length) {
+                cfg[key] = newDomainList;
+                let result = yield cfg.save();
                 if (!result) {
+                    Popup.enable(document.getElementById('advancedMode'));
                     Popup.enable(document.getElementById('filterMethodSelect'));
                     chrome.tabs.reload();
                 }
@@ -80,45 +96,58 @@ class Popup {
         return __awaiter(this, void 0, void 0, function* () {
             let popup = this;
             yield Popup.load(popup);
-            dynamicList(Config._filterMethodNames, 'filterMethodSelect');
             let domainFilter = document.getElementById('domainFilter');
             let domainToggle = document.getElementById('domainToggle');
+            let advancedMode = document.getElementById('advancedMode');
             let filterMethodSelect = document.getElementById('filterMethodSelect');
+            dynamicList(Config._filterMethodNames, 'filterMethodSelect');
+            filterMethodSelect.selectedIndex = popup.cfg.filterMethod;
             if (popup.cfg.password && popup.cfg.password != '') {
                 popup.protected = true;
                 Popup.disable(domainFilter);
                 Popup.disable(domainToggle);
+                Popup.disable(advancedMode);
                 Popup.disable(filterMethodSelect);
             }
-            filterMethodSelect.selectedIndex = popup.cfg.filterMethod;
             // Restricted pages
             if (popup.domain.url.protocol == 'chrome:' || popup.domain.url.protocol == 'about:' || popup.domain.hostname == 'chrome.google.com') {
                 domainFilter.checked = false;
                 Popup.disable(domainFilter);
                 Popup.disable(domainToggle);
+                Popup.disable(advancedMode);
                 Popup.disable(filterMethodSelect);
                 return false;
             }
-            // Set initial value for domain filter
-            let domainRegex;
-            for (let x = 0; x < popup.cfg.disabledDomains.length; x++) {
-                if (popup.cfg.disabledDomains[x]) {
-                    domainRegex = new RegExp('(^|\.)' + popup.cfg.disabledDomains[x]);
-                    if (domainRegex.test(popup.domain.hostname)) {
-                        domainFilter.checked = false;
-                        Popup.disable(filterMethodSelect);
-                        break;
-                    }
-                }
+            // Set initial value for domain filter and disable options if they are not applicable
+            if (Domain.domainMatch(popup.domain.hostname, popup.cfg['disabledDomains'])) {
+                domainFilter.checked = false;
+                Popup.disable(advancedMode);
+                Popup.disable(filterMethodSelect);
+            }
+            // Set initial value for advanced mode
+            if (Domain.domainMatch(popup.domain.hostname, popup.cfg['advancedDomains'])) {
+                advancedMode.checked = true;
             }
         });
+    }
+    toggleAdvancedMode() {
+        let popup = this;
+        if (!popup.protected) {
+            let advancedMode = document.getElementById('advancedMode');
+            if (advancedMode.checked) {
+                popup.enableAdvancedMode(popup.cfg, popup.domain.hostname, 'advancedDomains');
+            }
+            else {
+                popup.disableAdvancedMode(popup.cfg, popup.domain.hostname, 'advancedDomains');
+            }
+        }
     }
     toggleFilter() {
         let popup = this;
         if (!popup.protected) {
             let domainFilter = document.getElementById('domainFilter');
             if (domainFilter.checked) {
-                popup.enableDomain();
+                popup.enableDomain(popup.cfg, popup.domain.hostname, 'disabledDomains');
             }
             else {
                 popup.disableDomain();
@@ -131,5 +160,6 @@ let popup = new Popup;
 // Listeners
 window.addEventListener('load', function (event) { popup.populateOptions(); });
 document.getElementById('domainFilter').addEventListener('change', function (event) { popup.toggleFilter(); });
+document.getElementById('advancedMode').addEventListener('change', function (event) { popup.toggleAdvancedMode(); });
 document.getElementById('filterMethodSelect').addEventListener('change', function (event) { popup.filterMethodSelect(); });
 document.getElementById('options').addEventListener('click', function () { chrome.runtime.openOptionsPage(); });

--- a/dist/word.js
+++ b/dist/word.js
@@ -6,29 +6,82 @@ export default class Word {
         return string.toUpperCase() === string;
     }
     // Word must match exactly (not sub-string)
-    // /\b(w)ord\b/gi
-    static buildExactRegexp(word) {
-        return new RegExp('\\b(' + Word.escapeRegExp(word[0]) + ')' + Word.processRestOfWord(word.slice(1)) + '\\b', 'gi');
+    // /\bword\b/gi
+    static buildExactRegexp(str, matchRepeated = false) {
+        try {
+            if (Word.containsDoubleByte(str)) {
+                // Work around for lack of word boundary support for unicode characters
+                // /(^|[\s.,'"+!?|-]+)(word)([\s.,'"+!?|-]+|$)/giu
+                return new RegExp('(^|' + Word._unicodeWordBoundary + '+)(' + Word.processPhrase(str, matchRepeated) + ')(' + Word._unicodeWordBoundary + '+|$)', 'giu');
+            }
+            else {
+                return new RegExp('\\b' + Word.processPhrase(str, matchRepeated) + '\\b', 'gi');
+            }
+        }
+        catch (e) {
+            throw new Error('Failed to create RegExp for "' + str + '" - ' + e.name + ' ' + e.message);
+        }
     }
     // Match any part of a word (sub-string)
-    // /(w)ord/gi
-    static buildPartRegexp(word) {
-        return new RegExp('(' + Word.escapeRegExp(word[0]) + ')' + Word.processRestOfWord(word.slice(1)), 'gi');
+    // /word/gi
+    static buildPartRegexp(str, matchRepeated = false) {
+        try {
+            return new RegExp(Word.processPhrase(str, matchRepeated), 'gi');
+        }
+        catch (e) {
+            throw new Error('Failed to create RegExp for "' + str + '" - ' + e.name + ' ' + e.message);
+        }
     }
     // Match entire word that contains sub-string and surrounding whitespace
-    // /\s?\b(w)ord\b\s?/gi
-    static buildRegexpForRemoveExact(word) {
-        return new RegExp('\\s?\\b(' + Word.escapeRegExp(word[0]) + ')' + Word.processRestOfWord(word.slice(1)) + '\\b\\s?', 'gi');
+    // /\s?\bword\b\s?/gi
+    static buildRegexpForRemoveExact(str, matchRepeated = false) {
+        try {
+            if (Word.containsDoubleByte(str)) {
+                // Work around for lack of word boundary support for unicode characters
+                // /(^|[\s.,'"+!?|-]+)(word)([\s.,'"+!?|-]+|$)/giu
+                return new RegExp('(^|' + Word._unicodeWordBoundary + ')(' + Word.processPhrase(str, matchRepeated) + ')(' + Word._unicodeWordBoundary + '|$)', 'giu');
+            }
+            else {
+                return new RegExp('\\s?\\b' + Word.processPhrase(str, matchRepeated) + '\\b\\s?', 'gi');
+            }
+        }
+        catch (e) {
+            throw new Error('Failed to create RegExp for "' + str + '" - ' + e.name + ' ' + e.message);
+        }
     }
     // Match entire word that contains sub-string and surrounding whitespace
-    // /\s?\b[\w-]*(w)ord[\w-]*\b\s?/gi
-    static buildRegexpForRemovePart(word) {
-        return new RegExp('\\s?\\b([\\w-]*' + Word.escapeRegExp(word[0]) + ')' + Word.processRestOfWord(word.slice(1)) + '[\\w-]*\\b\\s?', 'gi');
+    // /\s?\b[\w-]*word[\w-]*\b\s?/gi
+    static buildRegexpForRemovePart(str, matchRepeated = false) {
+        try {
+            if (Word.containsDoubleByte(str)) {
+                // Work around for lack of word boundary support for unicode characters
+                // /(^|[\s.,'"+!?|-]?)[\w-]*(word)[\w-]*([\s.,'"+!?|-]?|$)/giu
+                return new RegExp('(^|' + Word._unicodeWordBoundary + '?)([\\w-]*' + Word.processPhrase(str, matchRepeated) + '[\\w-]*)(' + Word._unicodeWordBoundary + '?|$)', 'giu');
+            }
+            else {
+                return new RegExp('\\s?\\b[\\w-]*' + Word.processPhrase(str, matchRepeated) + '[\\w-]*\\b\\s?', 'gi');
+            }
+        }
+        catch (e) {
+            throw new Error('Failed to create RegExp for "' + str + '" - ' + e.name + ' ' + e.message);
+        }
     }
     // Match entire word that contains sub-string
-    // /\b[\w-]*(w)ord[\w-]*\b/gi
-    static buildWholeRegexp(word) {
-        return new RegExp('\\b([\\w-]*' + Word.escapeRegExp(word[0]) + ')' + Word.processRestOfWord(word.slice(1)) + '[\\w-]*\\b', 'gi');
+    // /\b[\w-]*word[\w-]*\b/gi
+    static buildWholeRegexp(str, matchRepeated = false) {
+        try {
+            if (Word.containsDoubleByte(str)) {
+                // Work around for lack of word boundary support for unicode characters
+                // (^|[\s.,'"+!?|-]*)([\w-]*куче[\w-]*)([\s.,'"+!?|-]*|$)/giu
+                return new RegExp('(^|' + Word._unicodeWordBoundary + '+)([\\w-]*' + Word.processPhrase(str, matchRepeated) + '[\\w-]*)(' + Word._unicodeWordBoundary + '+|$)', 'giu');
+            }
+            else {
+                return new RegExp('\\b[\\w-]*' + Word.processPhrase(str, matchRepeated) + '[\\w-]*\\b', 'gi');
+            }
+        }
+        catch (e) {
+            throw new Error('Failed to create RegExp for "' + str + '" - ' + e.name + ' ' + e.message);
+        }
     }
     static capitalize(string) {
         return string.charAt(0).toUpperCase() + string.substr(1);
@@ -36,14 +89,23 @@ export default class Word {
     static capitalized(string) {
         return string.charAt(0).toUpperCase() === string.charAt(0);
     }
+    static containsDoubleByte(str) {
+        if (!str.length)
+            return false;
+        if (str.charCodeAt(0) > 255)
+            return true;
+        return Word._unicodeRegex.test(str);
+    }
+    // /[-\/\\^$*+?.()|[\]{}]/g
+    // /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g
     static escapeRegExp(str) {
         return str.replace(Word._escapeRegExp, '\\$&');
     }
     // Process the rest of the word (word excluding first character)
     // This will escape the word and optionally include repeating characters
-    static processRestOfWord(str) {
+    static processPhrase(str, matchRepeated) {
         var escaped = Word.escapeRegExp(str);
-        if (filter && filter.cfg.matchRepeated) {
+        if (matchRepeated) {
             return Word.repeatingCharacterRegexp(escaped);
         }
         return escaped;
@@ -55,11 +117,10 @@ export default class Word {
         return array[Math.floor((Math.random() * array.length))];
     }
     // Regexp to match repeating characters
-    // Note: Skip first letter of word (used for preserveFirst)
-    // Word: /(w)+o+r+d+/gi
+    // Word: /w+o+r+d+/gi
     static repeatingCharacterRegexp(str) {
         if (str.includes('\\')) {
-            var repeat = '+';
+            var repeat = '';
             for (var i = 0; i < str.length; i++) {
                 if (str[i] === '\\') {
                     repeat += (str[i] + str[i + 1] + '+');
@@ -72,10 +133,12 @@ export default class Word {
             return repeat;
         }
         else {
-            return '+' + str.split('').map(letter => letter + '+').join('');
+            return str.split('').map(letter => letter + '+').join('');
         }
     }
 }
-// /[-\/\\^$*+?.()|[\]{}]/g
-// /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g
 Word._escapeRegExp = /[-\/\\^$*+?.()|[\]{}]/g;
+Word._unicodeRegex = /[^\u0000-\u00ff]/;
+Word._unicodeWordBoundary = '[\\s.,\'"+!?|-]';
+Word.nonWordRegExp = new RegExp('^\\s*[^\\w]\\s*$', 'g');
+Word.whitespaceRegExp = new RegExp('^\\s*$');

--- a/package.js
+++ b/package.js
@@ -13,10 +13,12 @@ function updateManifestFile(zip, obj) {
 }
 
 // Chrome Extension
+// try { fs.unlinkSync('./dist/filter.js'); } catch {};
 zip.addLocalFolder(dist, null)
 var manifest = JSON.parse(fs.readFileSync(path.join(dist, 'manifest.json')));
 manifest.version = process.env.npm_package_version || manifest.version;
 updateManifestFile(zip, manifest);
+zip.deleteFile('filter.js'); // Remove filter.js as its only used for testing. Use filter.bundle.js instead
 zip.writeZip('./extension-chrome.zip');
 
 // Firefox Extension

--- a/package.js
+++ b/package.js
@@ -2,50 +2,51 @@
 
 const fs = require('fs');
 const path = require('path');
-var AdmZip = require('adm-zip');
+const AdmZip = require('adm-zip');
 
-var zip = new AdmZip();
-var dist = './dist/'
+function buildChromeExtension(zip) {
+  // try { fs.unlinkSync('./dist/filter.js'); } catch {}; // Remove filter.js as its only used for testing
+  zip.deleteFile('filter.js'); // Remove filter.js as its only used for testing
+  zip.writeZip('./extension-chrome.zip');
+}
 
-function updateManifestFile(zip, obj) {
-  var content = JSON.stringify(obj, null, 2);
+// Firefox Extension
+function buildFirefox(manifest, zip) {
+  let firefoxManifest = {
+    "applications": {
+      "gecko": {
+        "id": "{853d1586-e2ab-4387-a7fd-1f7f894d2651}"
+      }
+    }
+  };
+  manifest.applications = firefoxManifest.applications;
+  updateManifestFileInZip(zip, manifest);
+  zip.writeZip('./extension-firefox.zip');
+}
+
+function updateManifestFile(file, obj) {
+  let content = JSON.stringify(obj, null, 2);
+  fs.writeFileSync(file, content);
+}
+
+function updateManifestFileInZip(zip, obj) {
+  let content = JSON.stringify(obj, null, 2);
   zip.updateFile('manifest.json', Buffer.alloc(content.length, content));
 }
 
-// Chrome Extension
-// try { fs.unlinkSync('./dist/filter.js'); } catch {};
-zip.addLocalFolder(dist, null)
-var manifest = JSON.parse(fs.readFileSync(path.join(dist, 'manifest.json')));
-manifest.version = process.env.npm_package_version || manifest.version;
-updateManifestFile(zip, manifest);
-zip.deleteFile('filter.js'); // Remove filter.js as its only used for testing. Use filter.bundle.js instead
-zip.writeZip('./extension-chrome.zip');
-
-// Firefox Extension
-var firefoxManifest = {
-  "applications": {
-    "gecko": {
-      "id": "{853d1586-e2ab-4387-a7fd-1f7f894d2651}"
-    }
+function updateManifestVersion(manifestPath, manifest) {
+  if (manifest.version != process.env.npm_package_version) {
+    console.log('Version number is being updated: ' + manifest.version + ' -> ' + process.env.npm_package_version)
+    manifest.version = process.env.npm_package_version || manifest.version;
+    updateManifestFile(manifestPath, manifest);
   }
-};
-manifest.applications = firefoxManifest.applications;
-updateManifestFile(zip, manifest);
-zip.writeZip('./extension-firefox.zip');
+}
 
-// function walkSync(dir, filelist = []) {
-//   fs.readdirSync(dir).forEach(file => {
-//     const dirFile = path.join(dir, file);
-//     try {
-//         filelist = walkSync(dirFile, filelist);
-//     }
-//     catch (err) {
-//         if (err.code === 'ENOTDIR' || err.code === 'EBUSY') filelist = [...filelist, dirFile];
-//         else throw err;
-//     }
-//   });
-//   return filelist;
-// }
-
-// var files = walkSync(dist);
-// files.forEach(file => { zip.addLocalFile(file); });
+const dist = './dist/'
+let zip = new AdmZip();
+let manifestPath = path.join(dist, 'manifest.json');
+let manifest = JSON.parse(fs.readFileSync(manifestPath));
+updateManifestVersion(manifestPath, manifest);
+zip.addLocalFolder(dist, null);
+buildChromeExtension(zip);
+buildFirefox(manifest, zip);

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "advancedprofanityfilter",
-  "version": "1.0.15",
+  "version": "1.1.0",
   "description": "A browser extension to filter profanity from webpages.",
   "main": "filter.js",
   "scripts": {
     "build": "node ./prebuild.js && npm run lint && echo \"Running tsc...\" & tsc",
     "build-no-verify": "node ./prebuild.js && echo \"Running tsc...\" & tsc",
     "lint": "npx eslint ./src/*.ts",
-    "package": "npm run build && node ./package.js",
+    "package": "npm run build && npm test && node ./package.js",
     "package-no-build": "node ./package.js",
     "test": "npx mocha --require babel-core/register test/**/*.spec.js"
   },


### PR DESCRIPTION
- Remove capture group from RegExps (Was used for first letter on censor method)
- Add Advanced Mode toggle to context menu
- Add Advanced Mode to Popup and Context Menu
- Change color of counter on Advanced Mode websites
- Catch errors on bad RegExps
- Add a repeating characters option for words
- `prebuild.js` is smarter and follows dependencies automatically
- Sanitize (downcase & trim) words on Import and once during extension upgrade
- Fix for Cyrillic words