### PR TITLE
Rewrite for 2.0.0 - TreeWalker and new Advanced Mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "advancedprofanityfilter",
-  "version": "1.2.2",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2365,6 +2365,37 @@
       "integrity": "sha1-wFTor02d11205jq8dviFFocU1LM=",
       "dev": true
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.1.1.tgz",
+      "integrity": "sha512-7uLG6yevcS3YNMnizbZjC1xCDD2RNwqbUAPFkjz80x3NeytlIExvPR40+meGwiJ+LilgJVlqqlDMFu7PHJ6Kzw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/parser": "1.1.1",
+        "requireindex": "^1.2.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-P6v+iYkI+ywp6MaFyAJ6NqU5W6fiAvMXWjCV63xTJbkQdtAngdjSCajlEEweqJqL4RNsgFCHBe5HbYyT6TmW4g==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "1.1.1",
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.1.1.tgz",
+      "integrity": "sha512-rERZSjNWb4WC425daCUktfh+0fFLy4WWlnu9bESdJv5l+t0ww0yUprRUbgzehag/dGd56Me+3uyXGV2O12qxrQ==",
+      "dev": true,
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.7.11",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
@@ -4107,15 +4138,6 @@
         "strip-json-comments": "^2.0.1",
         "table": "^4.0.3",
         "text-table": "^0.2.0"
-      }
-    },
-    "eslint-plugin-typescript": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript/-/eslint-plugin-typescript-0.14.0.tgz",
-      "integrity": "sha512-2u1WnnDF2mkWWgU1lFQ2RjypUlmRoBEvQN02y9u+IL12mjWlkKFGEBnVsjs9Y8190bfPQCvWly1c2rYYUSOxWw==",
-      "dev": true,
-      "requires": {
-        "requireindex": "~1.1.0"
       }
     },
     "eslint-scope": {
@@ -8227,9 +8249,9 @@
       }
     },
     "requireindex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
     },
     "resolve": {
@@ -9096,27 +9118,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
       "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
       "dev": true
-    },
-    "typescript-eslint-parser": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-21.0.2.tgz",
-      "integrity": "sha512-u+pj4RVJBr4eTzj0n5npoXD/oRthvfUCjSKndhNI714MG0mQq2DJw5WP7qmonRNIFgmZuvdDOH3BHm9iOjIAfg==",
-      "dev": true,
-      "requires": {
-        "eslint-scope": "^4.0.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "typescript-estree": "5.3.0"
-      }
-    },
-    "typescript-estree": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/typescript-estree/-/typescript-estree-5.3.0.tgz",
-      "integrity": "sha512-Vu0KmYdSCkpae+J48wsFC1ti19Hq3Wi/lODUaE+uesc3gzqhWbZ5itWbsjylLVbjNW4K41RqDzSfnaYNbmEiMQ==",
-      "dev": true,
-      "requires": {
-        "lodash.unescape": "4.0.1",
-        "semver": "5.5.0"
-      }
     },
     "unbzip2-stream": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/richardfrost/AdvancedProfanityFilter#readme",
   "scripts": {
     "build:test-sm": "babel src/script --out-dir built --extensions \".ts,.tsx\" --source-maps inline",
-    "build:test": "babel src/script --out-dir ./test/built --extensions \".ts,.tsx\"",
+    "build:test": "babel src/script --out-dir ./test/built --extensions \".ts,.tsx,.js\"",
     "build": "npm run copy-static && npm run package:webpack",
     "clean": "node bin/clean.js",
     "copy-static": "node bin/copy-static.js",
@@ -47,26 +47,34 @@
     "@babel/preset-typescript": "^7.1.0",
     "@babel/register": "^7.0.0",
     "@types/chrome": "latest",
+    "@typescript-eslint/eslint-plugin": "^1.1.1",
+    "@typescript-eslint/parser": "^1.1.1",
     "adm-zip": "^0.4.11",
     "babel-loader": "^8.0.4",
     "chai": "latest",
     "chokidar": "^2.0.4",
     "download": "^7.1.0",
     "eslint": "^5.2.0",
-    "eslint-plugin-typescript": "^0.14.0",
     "fs-extra": "^7.0.0",
     "marked": "^0.5.1",
     "mocha": "latest",
     "nyc": "latest",
     "typescript": "^3.2.2",
-    "typescript-eslint-parser": "^21.0.2",
     "webpack": "^4.28.1",
     "webpack-cli": "^3.1.2"
   },
   "babel": {
     "presets": [
       "@babel/typescript",
-      ["@babel/preset-env", {"modules": "commonjs", "targets": {"node": "current"}}]
+      [
+        "@babel/preset-env",
+        {
+          "modules": "commonjs",
+          "targets": {
+            "node": "current"
+          }
+        }
+      ]
     ],
     "plugins": [
       "@babel/proposal-class-properties",
@@ -74,29 +82,53 @@
     ]
   },
   "eslintConfig": {
-    "extends": "eslint:recommended",
-    "parser": "typescript-eslint-parser",
+    "extends": [
+      "eslint:recommended",
+      "plugin:@typescript-eslint/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module",
-      "ecmaFeatures": { }
+      "ecmaFeatures": {}
     },
     "plugins": [
-      "typescript"
+      "@typescript-eslint"
     ],
     "rules": {
+      "indent": "off",
       "no-console": "warn",
-      "no-control-regex": ["off"],
-      "no-undef": ["off"],
-      "no-unused-vars": ["off"],
-      "no-useless-escape": ["off"],
-      "quotes": ["error", "single"],
-      "semi": ["error", "always"],
-      "typescript/class-name-casing": "error",
-      "typescript/explicit-function-return-type": "off",
-      "typescript/no-unused-vars": "error",
-      "typescript/no-use-before-define": "off",
-      "typescript/type-annotation-spacing": "error"
+      "no-control-regex": [
+        "off"
+      ],
+      "no-undef": [
+        "off"
+      ],
+      "no-unused-vars": [
+        "off"
+      ],
+      "no-useless-escape": [
+        "off"
+      ],
+      "quotes": [
+        "error",
+        "single"
+      ],
+      "semi": [
+        "error",
+        "always"
+      ],
+      "@typescript-eslint/class-name-casing": "error",
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/indent": [
+        "error",
+        2
+      ],
+      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/no-use-before-define": "off",
+      "@typescript-eslint/explicit-member-accessibility": "off",
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/type-annotation-spacing": "error"
     }
   },
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,13 @@
         "error",
         2
       ],
-      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          "vars": "all",
+          "args": "none"
+        }
+      ],
       "@typescript-eslint/no-use-before-define": "off",
       "@typescript-eslint/explicit-member-accessibility": "off",
       "@typescript-eslint/no-explicit-any": "off",

--- a/src/script/eventPage.ts
+++ b/src/script/eventPage.ts
@@ -34,18 +34,18 @@ chrome.runtime.onInstalled.addListener(function(details){
 chrome.runtime.onMessage.addListener(
   function(request, sender, sendResponse) {
     if (request.disabled === true) {
-      chrome.browserAction.setIcon({path: 'img/icon19-disabled.png', tabId: sender.tab.id});
+      chrome.browserAction.setIcon({ path: 'img/icon19-disabled.png', tabId: sender.tab.id });
     } else {
       if (request.counter) {
-        chrome.browserAction.setBadgeText({text: request.counter, tabId: sender.tab.id});
+        chrome.browserAction.setBadgeText({ text: request.counter, tabId: sender.tab.id });
       }
 
       // Set badge color
       if (request.hasOwnProperty('advanced')) {
         if (request.advanced) {
-          chrome.browserAction.setBadgeBackgroundColor({ color: [211, 45, 39, 255] }); // Red - Advanced
+          chrome.browserAction.setBadgeBackgroundColor({ color: [211, 45, 39, 255], tabId: sender.tab.id }); // Red - Advanced
         } else {
-          chrome.browserAction.setBadgeBackgroundColor({ color: [66, 133, 244, 255] }); // Blue - Normal
+          chrome.browserAction.setBadgeBackgroundColor({ color: [66, 133, 244, 255], tabId: sender.tab.id }); // Blue - Normal
           // chrome.browserAction.setBadgeBackgroundColor({ color: [85, 85, 85, 255] }); // Grey - Normal
         }
       }

--- a/src/script/eventPage.ts
+++ b/src/script/eventPage.ts
@@ -40,10 +40,14 @@ chrome.runtime.onMessage.addListener(
         chrome.browserAction.setBadgeText({text: request.counter, tabId: sender.tab.id});
       }
 
-      if (request.advanced === true) {
-        chrome.browserAction.setBadgeBackgroundColor({ color: [211, 45, 39, 255] }); // Red - Advanced
-      } else if (request.advanced === false) {
-        chrome.browserAction.setBadgeBackgroundColor({ color: [66, 133, 244, 255] }); // Blue - Normal
+      // Set badge color
+      if (request.hasOwnProperty('advanced')) {
+        if (request.advanced) {
+          chrome.browserAction.setBadgeBackgroundColor({ color: [211, 45, 39, 255] }); // Red - Advanced
+        } else {
+          chrome.browserAction.setBadgeBackgroundColor({ color: [66, 133, 244, 255] }); // Blue - Normal
+          // chrome.browserAction.setBadgeBackgroundColor({ color: [85, 85, 85, 255] }); // Grey - Normal
+        }
       }
 
       if (request.mute != undefined) {

--- a/src/script/lib/filter.ts
+++ b/src/script/lib/filter.ts
@@ -20,60 +20,53 @@ export class Filter {
   // Parse the profanity list
   // ["exact", "partial", "whole", "disabled"]
   generateRegexpList() {
-    // Clean wordRegExps if there are already some present
-    if (this.wordRegExps.length > 0) this.wordRegExps = [];
+    let self = this;
+    self.wordRegExps = [];
 
     // console.time('generateRegexpList'); // Benchmark - Call Time
     // console.count('generateRegexpList: words to filter'); // Benchmarking - Executaion Count
-    if (this.cfg.filterMethod == 2) { // Special regexp for "Remove" filter, uses per-word matchMethods
-      for (let x = 0; x < this.wordList.length; x++) {
-        let repeat = this.cfg.repeatForWord(this.wordList[x]);
-        if (this.cfg.words[this.wordList[x]].matchMethod == 0) { // If word matchMethod is exact
-          this.wordRegExps.push(Word.buildRegexpForRemoveExact(this.wordList[x], repeat));
-        } else if (this.cfg.words[this.wordList[x]].matchMethod == 4) { // If word matchMethod is RegExp
-          this.wordRegExps.push(new RegExp(this.wordList[x], 'gi'));
+    if (self.cfg.filterMethod == 2) { // Special regexp for "Remove" filter, uses per-word matchMethods
+      self.wordList.forEach(word => {
+        let repeat = self.cfg.repeatForWord(word);
+
+        if (self.cfg.words[word].matchMethod == 0) { // If word matchMethod is exact
+          self.wordRegExps.push(Word.buildRegexpForRemoveExact(word, repeat));
+        } else if (self.cfg.words[word].matchMethod == 4) { // If word matchMethod is RegExp
+          self.wordRegExps.push(new RegExp(word, 'gi'));
         } else {
-          this.wordRegExps.push(Word.buildRegexpForRemovePart(this.wordList[x], repeat));
+          self.wordRegExps.push(Word.buildRegexpForRemovePart(word, repeat));
         }
-      }
+      });
     } else {
-      switch(this.cfg.globalMatchMethod) {
+      switch(self.cfg.globalMatchMethod) {
         case 0: // Global: Exact match
-          for (let x = 0; x < this.wordList.length; x++) {
-            let repeat = this.cfg.repeatForWord(this.wordList[x]);
-            this.wordRegExps.push(Word.buildExactRegexp(this.wordList[x], repeat));
-          }
+          self.wordList.forEach(word => {
+            let repeat = self.cfg.repeatForWord(word);
+            self.wordRegExps.push(Word.buildExactRegexp(word, repeat));
+          });
           break;
         case 2: // Global: Whole word match
-          for (let x = 0; x < this.wordList.length; x++) {
-            let repeat = this.cfg.repeatForWord(this.wordList[x]);
-            this.wordRegExps.push(Word.buildWholeRegexp(this.wordList[x], repeat));
-          }
+          self.wordList.forEach(word => {
+            let repeat = self.cfg.repeatForWord(word);
+            self.wordRegExps.push(Word.buildWholeRegexp(word, repeat));
+          });
           break;
         case 3: // Per-word matching
-          for (let x = 0; x < this.wordList.length; x++) {
-            let repeat = this.cfg.repeatForWord(this.wordList[x]);
-            switch(this.cfg.words[this.wordList[x]].matchMethod) {
-              case 0: // Exact match
-                this.wordRegExps.push(Word.buildExactRegexp(this.wordList[x], repeat));
-                break;
-              case 2: // Whole word match
-                this.wordRegExps.push(Word.buildWholeRegexp(this.wordList[x], repeat));
-                break;
-              case 4: // Regular Expression (Advanced)
-                this.wordRegExps.push(new RegExp(this.wordList[x], 'gi'));
-                break;
-              default: // case 1 - Partial word match (Default)
-              this.wordRegExps.push(Word.buildPartRegexp(this.wordList[x], repeat));
-                break;
+          self.wordList.forEach(word => {
+            let repeat = self.cfg.repeatForWord(word);
+            switch(self.cfg.words[word].matchMethod) {
+              case 0: self.wordRegExps.push(Word.buildExactRegexp(word, repeat)); break; // Exact match
+              case 2: self.wordRegExps.push(Word.buildWholeRegexp(word, repeat)); break; // Whole word match
+              case 4: self.wordRegExps.push(new RegExp(word, 'gi')); break; // Regular Expression (Advanced)
+              default: self.wordRegExps.push(Word.buildPartRegexp(word, repeat)); break; // case 1 - Partial word match (Default)
             }
-          }
+          });
           break;
         default: // case 1 - Global: Partial word match (Default)
-          for (let x = 0; x < this.wordList.length; x++) {
-            let repeat = this.cfg.repeatForWord(this.wordList[x]);
-            this.wordRegExps.push(Word.buildPartRegexp(this.wordList[x], repeat));
-          }
+          self.wordList.forEach(word => {
+            let repeat = self.cfg.repeatForWord(word);
+            self.wordRegExps.push(Word.buildPartRegexp(word, repeat));
+          });
           break;
       }
     }
@@ -83,10 +76,8 @@ export class Filter {
   // Sort the words array by longest (most-specific) first
   // Config Dependencies: words
   generateWordList() {
-    // Clean wordRegExps if there are already some present
-    if (this.wordList.length > 0) this.wordList = null;
-
-    this.wordList = Object.keys(this.cfg.words).sort(function(a, b) {
+    this.wordList = null;
+    this.wordList = Object.keys(this.cfg.words).sort((a, b) => {
       return b.length - a.length;
     });
   }
@@ -99,10 +90,10 @@ export class Filter {
     let self = this;
     switch(self.cfg.filterMethod) {
       case 0: // Censor
-        for (let z = 0; z < self.wordList.length; z++) {
-          str = str.replace(self.wordRegExps[z], function(match, arg1, arg2, arg3, arg4, arg5): string {
-            if (stats) { self.foundMatch(self.wordList[z]); }
-            if (self.wordRegExps[z].unicode) { match = arg2; } // Workaround for unicode word boundaries
+        self.wordRegExps.forEach((regExp, index) => {
+          str = str.replace(regExp, function(match, arg1, arg2, arg3, arg4, arg5): string {
+            if (stats) { self.foundMatch(self.wordList[index]); }
+            if (regExp.unicode) { match = arg2; } // Workaround for unicode word boundaries
             let censoredString = '';
             let censorLength = self.cfg.censorFixedLength > 0 ? self.cfg.censorFixedLength : match.length;
 
@@ -116,19 +107,18 @@ export class Filter {
               censoredString = self.cfg.censorCharacter.repeat(censorLength);
             }
 
-            if (self.wordRegExps[z].unicode) { censoredString = arg1 + censoredString + arg3; } // Workaround for unicode word boundaries
+            if (regExp.unicode) { censoredString = arg1 + censoredString + arg3; } // Workaround for unicode word boundaries
             // console.log('Censor match:', match, censoredString); // DEBUG
             return censoredString;
           });
-        }
+        });
         break;
       case 1: // Substitute
-        for (let z = 0; z < self.wordList.length; z++) {
-          str = str.replace(self.wordRegExps[z], function(match, arg1, arg2, arg3, arg4, arg5): string {
-            // console.log('Substitute match:', match, self.cfg.words[self.wordList[z]].words); // DEBUG
-            if (stats) { self.foundMatch(self.wordList[z]); }
-            if (self.wordRegExps[z].unicode) { match = arg2; } // Workaround for unicode word boundaries
-            let sub = self.cfg.words[self.wordList[z]].sub || self.cfg.defaultSubstitution;
+        self.wordRegExps.forEach((regExp, index) => {
+          str = str.replace(regExp, function(match, arg1, arg2, arg3, arg4, arg5): string {
+            if (stats) { self.foundMatch(self.wordList[index]); }
+            if (regExp.unicode) { match = arg2; } // Workaround for unicode word boundaries
+            let sub = self.cfg.words[self.wordList[index]].sub || self.cfg.defaultSubstitution;
 
             // Make substitution match case of original match
             if (self.cfg.preserveCase) {
@@ -143,18 +133,18 @@ export class Filter {
               sub = '[' + sub + ']';
             }
 
-            if (self.wordRegExps[z].unicode) { sub = arg1 + sub + arg3; } // Workaround for unicode word boundaries
+            if (regExp.unicode) { sub = arg1 + sub + arg3; } // Workaround for unicode word boundaries
+            // console.log('Substitute match:', match, sub); // DEBUG
             return sub;
           });
-        }
+        });
         break;
       case 2: // Remove
-        for (let z = 0; z < self.wordList.length; z++) {
-          str = str.replace(self.wordRegExps[z], function(match, arg1, arg2, arg3, arg4, arg5): string {
-            // console.log('Remove match:', match, self.cfg.words[self.wordList[z]].words); // DEBUG
+        self.wordRegExps.forEach((regExp, index) => {
+          str = str.replace(regExp, function(match, arg1, arg2, arg3, arg4, arg5): string {
             // console.log('\nmatch: ', match, '\narg1: ', arg1, '\narg2: ', arg2, '\narg3: ', arg3, '\narg4: ', arg4, '\narg5: ', arg5); // DEBUG
-            if (stats) { self.foundMatch(self.wordList[z]); }
-            if (self.wordRegExps[z].unicode) {
+            if (stats) { self.foundMatch(self.wordList[index]); }
+            if (regExp.unicode) {
               // Workaround for unicode word boundaries
               if (Word.whitespaceRegExp.test(arg1) && Word.whitespaceRegExp.test(arg3)) { // If both surrounds are whitespace (only need 1)
                 return arg1;
@@ -165,17 +155,18 @@ export class Filter {
               }
             } else {
               // Don't remove both leading and trailing whitespace
-              // console.log('Remove match:', match); // DEBUG
               if (Word.whitespaceRegExp.test(match[0]) && Word.whitespaceRegExp.test(match[match.length - 1])) {
                 return match[0];
               } else {
+                // console.log('Remove match:', match); // DEBUG
                 return '';
               }
             }
           });
-        }
+        });
         break;
     }
+
     return str;
   }
 

--- a/src/script/lib/filter.ts
+++ b/src/script/lib/filter.ts
@@ -85,7 +85,7 @@ export class Filter {
   // Config Dependencies: filterMethod, wordList,
   // censorFixedLength, preserveFirst, preserveLast, censorCharacter
   // words, defaultSubstitution, preserveCase
-  replaceText(str: string, stats = true): string {
+  replaceText(str: string, stats: boolean = true): string {
     // console.count('replaceText'); // Benchmarking - Executaion Count
     let self = this;
     switch(self.cfg.filterMethod) {

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -53,7 +53,7 @@ export default class OptionPage {
       element.setCustomValidity('');
     } catch(e) {
       // If HTML5 validation not supported, the modal will suffice
-     }
+    }
   }
 
   static hideStatus() {
@@ -79,7 +79,7 @@ export default class OptionPage {
     OptionPage.openModal('statusModal');
   }
 
- static showInputError(element, message = '') {
+  static showInputError(element, message = '') {
     element.classList.add('w3-border-red');
     if (message) {
       try {

--- a/src/script/page.ts
+++ b/src/script/page.ts
@@ -11,11 +11,20 @@ export default class Page {
   // Returns true if a node should *not* be altered in any way
   // Credit: https://github.com/ericwbailey/millennials-to-snake-people/blob/master/Source/content_script.js
   static isForbiddenNode(node: any, advanced: boolean = false): boolean {
-    if (node.parentNode) { node = node.parentNode }
     if (node.isContentEditable) { return true; }
-    return Page.forbiddenTag(node.tagName, advanced);
+
+    if (node.parentNode && Page.forbiddenTag(Page.getTagFromNode(node.parentNode), advanced)) {
+      return true;
+    }
+
+    return Page.forbiddenTag(Page.getTagFromNode(node), advanced);
   }
 
+  static getTagFromNode(node): string {
+    return node.tagName || node.nodeName;
+  }
+
+  // TODO: Remove advanced
   static forbiddenTag(tagName: string, advanced: boolean): boolean {
     return Boolean (
       Page.forbiddenTags.includes(tagName) ||

--- a/src/script/page.ts
+++ b/src/script/page.ts
@@ -2,33 +2,24 @@ export default class Page {
   xpathDocText: string;
   xpathNodeText: string;
 
-  static readonly allowedAdvancedTags = ['SCRIPT'];
   static readonly forbiddenNodeRegExp = new RegExp('^\s*(<[a-z].+?\/?>|{.+?:.+?;.*}|https?:\/\/[^\s]+$)');
-  static readonly forbiddenTags = ['LINK', 'STYLE', 'INPUT', 'TEXTAREA', 'IFRAME'];
-  static readonly xpathDocText = '//*[not(self::script or self::style)]/text()[normalize-space(.) != \"\"]';
-  static readonly xpathNodeText = './/*[not(self::script or self::style)]/text()[normalize-space(.) != \"\"]';
-
-  // Returns true if a node should *not* be altered in any way
-  // Credit: https://github.com/ericwbailey/millennials-to-snake-people/blob/master/Source/content_script.js
-  static isForbiddenNode(node: any, advanced: boolean = false): boolean {
-    if (node.isContentEditable) { return true; }
-
-    if (node.parentNode && Page.forbiddenTag(Page.getTagFromNode(node.parentNode), advanced)) {
-      return true;
-    }
-
-    return Page.forbiddenTag(Page.getTagFromNode(node), advanced);
-  }
+  static readonly forbiddenTags = ['SCRIPT', 'STYLE', 'INPUT', 'TEXTAREA', 'IFRAME', 'LINK'];
 
   static getTagFromNode(node): string {
     return node.tagName || node.nodeName;
   }
 
-  // TODO: Remove advanced
-  static forbiddenTag(tagName: string, advanced: boolean): boolean {
-    return Boolean (
-      Page.forbiddenTags.includes(tagName) ||
-      (!advanced && Page.allowedAdvancedTags.includes(tagName))
-    );
+  // Returns true if a node should *not* be altered in any way
+  static isForbiddenNode(node: any): boolean {
+    if (node.isContentEditable) { return true; }
+
+    // Check if parentNode is a forbidden tag
+    if (node.parentNode && (
+      node.parentNode.isContentEditable ||
+      Page.forbiddenTags.includes(Page.getTagFromNode(node.parentNode)))
+    ) { return true; }
+
+    // Check if node is a forbidden tag
+    return Page.forbiddenTags.includes(Page.getTagFromNode(node));
   }
 }

--- a/src/script/page.ts
+++ b/src/script/page.ts
@@ -2,36 +2,24 @@ export default class Page {
   xpathDocText: string;
   xpathNodeText: string;
 
+  static readonly allowedAdvancedTags = ['SCRIPT'];
   static readonly forbiddenNodeRegExp = new RegExp('^\s*(<[a-z].+?\/?>|{.+?:.+?;.*}|https?:\/\/[^\s]+$)');
+  static readonly forbiddenTags = ['LINK', 'STYLE', 'INPUT', 'TEXTAREA', 'IFRAME'];
   static readonly xpathDocText = '//*[not(self::script or self::style)]/text()[normalize-space(.) != \"\"]';
   static readonly xpathNodeText = './/*[not(self::script or self::style)]/text()[normalize-space(.) != \"\"]';
 
   // Returns true if a node should *not* be altered in any way
   // Credit: https://github.com/ericwbailey/millennials-to-snake-people/blob/master/Source/content_script.js
-  static isForbiddenNode(node: any): boolean {
-    return Boolean(
-      node.isContentEditable || // DraftJS and many others
-      (node.parentNode &&
-        (
-          node.parentNode.isContentEditable || // Special case for Gmail
-          node.parentNode.tagName == 'LINK' ||
-          node.parentNode.tagName == 'SCRIPT' ||
-          node.parentNode.tagName == 'STYLE' ||
-          node.parentNode.tagName == 'INPUT' ||
-          node.parentNode.tagName == 'TEXTAREA' ||
-          node.parentNode.tagName == 'IFRAME'
-        )
-      ) || // Some catch-alls
-      (node.tagName &&
-        (
-          node.tagName == 'LINK' ||
-          node.tagName == 'SCRIPT' ||
-          node.tagName == 'STYLE' ||
-          node.tagName == 'INPUT' ||
-          node.tagName == 'TEXTAREA' ||
-          node.tagName == 'IFRAME'
-        )
-      )
+  static isForbiddenNode(node: any, advanced: boolean = false): boolean {
+    if (node.parentNode) { node = node.parentNode }
+    if (node.isContentEditable) { return true; }
+    return Page.forbiddenTag(node.tagName, advanced);
+  }
+
+  static forbiddenTag(tagName: string, advanced: boolean): boolean {
+    return Boolean (
+      Page.forbiddenTags.includes(tagName) ||
+      (!advanced && Page.allowedAdvancedTags.includes(tagName))
     );
   }
 }

--- a/src/script/popup.ts
+++ b/src/script/popup.ts
@@ -6,7 +6,7 @@ interface Summary {
   [word: string]: {
     clean: string;
     count: number;
-  }
+  };
 }
 
 class Popup {

--- a/src/script/vendor/findAndReplaceDOMText.js
+++ b/src/script/vendor/findAndReplaceDOMText.js
@@ -1,0 +1,647 @@
+/**
+ * findAndReplaceDOMText v 0.4.6
+ * @author James Padolsey http://james.padolsey.com
+ * @license http://unlicense.org/UNLICENSE
+ *
+ * Matches the text of a DOM node against a regular expression
+ * and replaces each match (or node-separated portions of the match)
+ * in the specified element.
+ */
+(function (root, factory) {
+	/////////////////////////////
+	// Modifications:
+	// 1. Comment out below code
+	// 2. Attach function to global scope
+	//
+	// if (typeof module === 'object' && module.exports) {
+	// 		// Node/CommonJS
+	// 		module.exports = factory();
+	// } else if (typeof define === 'function' && define.amd) {
+	// 		// AMD. Register as an anonymous module.
+	// 		define(factory);
+	// } else {
+	// 		// Browser globals
+	// 		root.findAndReplaceDOMText = factory();
+	// }
+
+	// Only run in a browser
+	if (typeof window !== 'undefined') {
+		// Attach function to global scope
+		window.findAndReplaceDOMText = factory();
+	}
+}(this, function factory() {
+
+var PORTION_MODE_RETAIN = 'retain';
+var PORTION_MODE_FIRST = 'first';
+
+var doc = document;
+var hasOwn = {}.hasOwnProperty;
+
+function escapeRegExp(s) {
+ return String(s).replace(/([.*+?^=!:${}()|[\]\/\\])/g, '\\$1');
+}
+
+function exposed() {
+ // Try deprecated arg signature first:
+ return deprecated.apply(null, arguments) || findAndReplaceDOMText.apply(null, arguments);
+}
+
+function deprecated(regex, node, replacement, captureGroup, elFilter) {
+ if ((node && !node.nodeType) && arguments.length <= 2) {
+	 return false;
+ }
+ var isReplacementFunction = typeof replacement == 'function';
+
+ if (isReplacementFunction) {
+	 replacement = (function(original) {
+		 return function(portion, match) {
+			 return original(portion.text, match.startIndex);
+		 };
+	 }(replacement));
+ }
+
+ // Awkward support for deprecated argument signature (<0.4.0)
+ var instance = findAndReplaceDOMText(node, {
+
+	 find: regex,
+
+	 wrap: isReplacementFunction ? null : replacement,
+	 replace: isReplacementFunction ? replacement : '$' + (captureGroup || '&'),
+
+	 prepMatch: function(m, mi) {
+
+		 // Support captureGroup (a deprecated feature)
+
+		 if (!m[0]) throw 'findAndReplaceDOMText cannot handle zero-length matches';
+
+		 if (captureGroup > 0) {
+			 var cg = m[captureGroup];
+			 m.index += m[0].indexOf(cg);
+			 m[0] = cg;
+		 }
+
+		 m.endIndex = m.index + m[0].length;
+		 m.startIndex = m.index;
+		 m.index = mi;
+
+		 return m;
+	 },
+	 filterElements: elFilter
+ });
+
+ exposed.revert = function() {
+	 return instance.revert();
+ };
+
+ return true;
+}
+
+/**
+* findAndReplaceDOMText
+*
+* Locates matches and replaces with replacementNode
+*
+* @param {Node} node Element or Text node to search within
+* @param {RegExp} options.find The regular expression to match
+* @param {String|Element} [options.wrap] A NodeName, or a Node to clone
+* @param {String} [options.wrapClass] A classname to append to the wrapping element
+* @param {String|Function} [options.replace='$&'] What to replace each match with
+* @param {Function} [options.filterElements] A Function to be called to check whether to
+*	process an element. (returning true = process element,
+*	returning false = avoid element)
+*/
+function findAndReplaceDOMText(node, options) {
+ return new Finder(node, options);
+}
+
+exposed.NON_PROSE_ELEMENTS = {
+ br:1, hr:1,
+ // Media / Source elements:
+ script:1, style:1, img:1, video:1, audio:1, canvas:1, svg:1, map:1, object:1,
+ // Input elements
+ input:1, textarea:1, select:1, option:1, optgroup: 1, button:1
+};
+
+exposed.NON_CONTIGUOUS_PROSE_ELEMENTS = {
+
+ // Elements that will not contain prose or block elements where we don't
+ // want prose to be matches across element borders:
+
+ // Block Elements
+ address:1, article:1, aside:1, blockquote:1, dd:1, div:1,
+ dl:1, fieldset:1, figcaption:1, figure:1, footer:1, form:1, h1:1, h2:1, h3:1,
+ h4:1, h5:1, h6:1, header:1, hgroup:1, hr:1, main:1, nav:1, noscript:1, ol:1,
+ output:1, p:1, pre:1, section:1, ul:1,
+ // Other misc. elements that are not part of continuous inline prose:
+ br:1, li: 1, summary: 1, dt:1, details:1, rp:1, rt:1, rtc:1,
+ // Media / Source elements:
+ script:1, style:1, img:1, video:1, audio:1, canvas:1, svg:1, map:1, object:1,
+ // Input elements
+ input:1, textarea:1, select:1, option:1, optgroup:1, button:1,
+ // Table related elements:
+ table:1, tbody:1, thead:1, th:1, tr:1, td:1, caption:1, col:1, tfoot:1, colgroup:1
+
+};
+
+exposed.NON_INLINE_PROSE = function(el) {
+ return hasOwn.call(exposed.NON_CONTIGUOUS_PROSE_ELEMENTS, el.nodeName.toLowerCase());
+};
+
+// Presets accessed via `options.preset` when calling findAndReplaceDOMText():
+exposed.PRESETS = {
+ prose: {
+	 forceContext: exposed.NON_INLINE_PROSE,
+	 filterElements: function(el) {
+		 return !hasOwn.call(exposed.NON_PROSE_ELEMENTS, el.nodeName.toLowerCase());
+	 }
+ }
+};
+
+exposed.Finder = Finder;
+
+/**
+* Finder -- encapsulates logic to find and replace.
+*/
+function Finder(node, options) {
+
+ var preset = options.preset && exposed.PRESETS[options.preset];
+
+ options.portionMode = options.portionMode || PORTION_MODE_RETAIN;
+
+ if (preset) {
+	 for (var i in preset) {
+		 if (hasOwn.call(preset, i) && !hasOwn.call(options, i)) {
+			 options[i] = preset[i];
+		 }
+	 }
+ }
+
+ this.node = node;
+ this.options = options;
+
+ // Enable match-preparation method to be passed as option:
+ this.prepMatch = options.prepMatch || this.prepMatch;
+
+ this.reverts = [];
+
+ this.matches = this.search();
+
+ if (this.matches.length) {
+	 this.processMatches();
+ }
+
+}
+
+Finder.prototype = {
+
+ /**
+	* Searches for all matches that comply with the instance's 'match' option
+	*/
+ search: function() {
+
+	 var match;
+	 var matchIndex = 0;
+	 var offset = 0;
+	 var regex = this.options.find;
+	 var textAggregation = this.getAggregateText();
+	 var matches = [];
+	 var self = this;
+
+	 regex = typeof regex === 'string' ? RegExp(escapeRegExp(regex), 'g') : regex;
+
+	 matchAggregation(textAggregation);
+
+	 function matchAggregation(textAggregation) {
+		 for (var i = 0, l = textAggregation.length; i < l; ++i) {
+
+			 var text = textAggregation[i];
+
+			 if (typeof text !== 'string') {
+				 // Deal with nested contexts: (recursive)
+				 matchAggregation(text);
+				 continue;
+			 }
+
+			 if (regex.global) {
+				 while (match = regex.exec(text)) {
+					 matches.push(self.prepMatch(match, matchIndex++, offset));
+				 }
+			 } else {
+				 if (match = text.match(regex)) {
+					 matches.push(self.prepMatch(match, 0, offset));
+				 }
+			 }
+
+			 offset += text.length;
+		 }
+	 }
+
+	 return matches;
+
+ },
+
+ /**
+	* Prepares a single match with useful meta info:
+	*/
+ prepMatch: function(match, matchIndex, characterOffset) {
+
+	 if (!match[0]) {
+		 throw new Error('findAndReplaceDOMText cannot handle zero-length matches');
+	 }
+
+	 match.endIndex = characterOffset + match.index + match[0].length;
+	 match.startIndex = characterOffset + match.index;
+	 match.index = matchIndex;
+
+	 return match;
+ },
+
+ /**
+	* Gets aggregate text within subject node
+	*/
+ getAggregateText: function() {
+
+	 var elementFilter = this.options.filterElements;
+	 var forceContext = this.options.forceContext;
+
+	 return getText(this.node);
+
+	 /**
+		* Gets aggregate text of a node without resorting
+		* to broken innerText/textContent
+		*/
+	 function getText(node) {
+
+		 if (node.nodeType === Node.TEXT_NODE) {
+			 return [node.data];
+		 }
+
+		 if (elementFilter && !elementFilter(node)) {
+			 return [];
+		 }
+
+		 var txt = [''];
+		 var i = 0;
+
+		 if (node = node.firstChild) do {
+
+			 if (node.nodeType === Node.TEXT_NODE) {
+				 txt[i] += node.data;
+				 continue;
+			 }
+
+			 var innerText = getText(node);
+
+			 if (
+				 forceContext &&
+				 node.nodeType === Node.ELEMENT_NODE &&
+				 (forceContext === true || forceContext(node))
+			 ) {
+				 txt[++i] = innerText;
+				 txt[++i] = '';
+			 } else {
+				 if (typeof innerText[0] === 'string') {
+					 // Bridge nested text-node data so that they're
+					 // not considered their own contexts:
+					 // I.e. ['some', ['thing']] -> ['something']
+					 txt[i] += innerText.shift();
+				 }
+				 if (innerText.length) {
+					 txt[++i] = innerText;
+					 txt[++i] = '';
+				 }
+			 }
+		 } while (node = node.nextSibling);
+
+		 return txt;
+
+	 }
+
+ },
+
+ /**
+	* Steps through the target node, looking for matches, and
+	* calling replaceFn when a match is found.
+	*/
+ processMatches: function() {
+
+	 var matches = this.matches;
+	 var node = this.node;
+	 var elementFilter = this.options.filterElements;
+
+	 var startPortion,
+		 endPortion,
+		 innerPortions = [],
+		 curNode = node,
+		 match = matches.shift(),
+		 atIndex = 0, // i.e. nodeAtIndex
+		 matchIndex = 0,
+		 portionIndex = 0,
+		 doAvoidNode,
+		 nodeStack = [node];
+
+	 out: while (true) {
+
+		 if (curNode.nodeType === Node.TEXT_NODE) {
+
+			 if (!endPortion && curNode.length + atIndex >= match.endIndex) {
+				 // We've found the ending
+				 // (Note that, in the case of a single portion, it'll be an
+				 // endPortion, not a startPortion.)
+				 endPortion = {
+					 node: curNode,
+					 index: portionIndex++,
+					 text: curNode.data.substring(match.startIndex - atIndex, match.endIndex - atIndex),
+
+					 // If it's the first match (atIndex==0) we should just return 0
+					 indexInMatch: atIndex === 0 ? 0 : atIndex - match.startIndex,
+
+					 indexInNode: match.startIndex - atIndex,
+					 endIndexInNode: match.endIndex - atIndex,
+					 isEnd: true
+				 };
+
+			 } else if (startPortion) {
+				 // Intersecting node
+				 innerPortions.push({
+					 node: curNode,
+					 index: portionIndex++,
+					 text: curNode.data,
+					 indexInMatch: atIndex - match.startIndex,
+					 indexInNode: 0 // always zero for inner-portions
+				 });
+			 }
+
+			 if (!startPortion && curNode.length + atIndex > match.startIndex) {
+				 // We've found the match start
+				 startPortion = {
+					 node: curNode,
+					 index: portionIndex++,
+					 indexInMatch: 0,
+					 indexInNode: match.startIndex - atIndex,
+					 endIndexInNode: match.endIndex - atIndex,
+					 text: curNode.data.substring(match.startIndex - atIndex, match.endIndex - atIndex)
+				 };
+			 }
+
+			 atIndex += curNode.data.length;
+
+		 }
+
+		 doAvoidNode = curNode.nodeType === Node.ELEMENT_NODE && elementFilter && !elementFilter(curNode);
+
+		 if (startPortion && endPortion) {
+
+			 curNode = this.replaceMatch(match, startPortion, innerPortions, endPortion);
+
+			 // processMatches has to return the node that replaced the endNode
+			 // and then we step back so we can continue from the end of the
+			 // match:
+
+			 atIndex -= (endPortion.node.data.length - endPortion.endIndexInNode);
+
+			 startPortion = null;
+			 endPortion = null;
+			 innerPortions = [];
+			 match = matches.shift();
+			 portionIndex = 0;
+			 matchIndex++;
+
+			 if (!match) {
+				 break; // no more matches
+			 }
+
+		 } else if (
+			 !doAvoidNode &&
+			 (curNode.firstChild || curNode.nextSibling)
+		 ) {
+			 // Move down or forward:
+			 if (curNode.firstChild) {
+				 nodeStack.push(curNode);
+				 curNode = curNode.firstChild;
+			 } else {
+				 curNode = curNode.nextSibling;
+			 }
+			 continue;
+		 }
+
+		 // Move forward or up:
+		 while (true) {
+			 if (curNode.nextSibling) {
+				 curNode = curNode.nextSibling;
+				 break;
+			 }
+			 curNode = nodeStack.pop();
+			 if (curNode === node) {
+				 break out;
+			 }
+		 }
+
+	 }
+
+ },
+
+ /**
+	* Reverts ... TODO
+	*/
+ revert: function() {
+	 // Reversion occurs backwards so as to avoid nodes subsequently
+	 // replaced during the matching phase (a forward process):
+	 for (var l = this.reverts.length; l--;) {
+		 this.reverts[l]();
+	 }
+	 this.reverts = [];
+ },
+
+ prepareReplacementString: function(string, portion, match) {
+	 var portionMode = this.options.portionMode;
+	 if (
+		 portionMode === PORTION_MODE_FIRST &&
+		 portion.indexInMatch > 0
+	 ) {
+		 return '';
+	 }
+	 string = string.replace(/\$(\d+|&|`|')/g, function($0, t) {
+		 var replacement;
+		 switch(t) {
+			 case '&':
+				 replacement = match[0];
+				 break;
+			 case '`':
+				 replacement = match.input.substring(0, match.startIndex);
+				 break;
+			 case '\'':
+				 replacement = match.input.substring(match.endIndex);
+				 break;
+			 default:
+				 replacement = match[+t] || '';
+		 }
+		 return replacement;
+	 });
+
+	 if (portionMode === PORTION_MODE_FIRST) {
+		 return string;
+	 }
+
+	 if (portion.isEnd) {
+		 return string.substring(portion.indexInMatch);
+	 }
+
+	 return string.substring(portion.indexInMatch, portion.indexInMatch + portion.text.length);
+ },
+
+ getPortionReplacementNode: function(portion, match) {
+
+	 var replacement = this.options.replace || '$&';
+	 var wrapper = this.options.wrap;
+	 var wrapperClass = this.options.wrapClass;
+
+	 if (wrapper && wrapper.nodeType) {
+		 // Wrapper has been provided as a stencil-node for us to clone:
+		 var clone = doc.createElement('div');
+		 clone.innerHTML = wrapper.outerHTML || new XMLSerializer().serializeToString(wrapper);
+		 wrapper = clone.firstChild;
+	 }
+
+	 if (typeof replacement == 'function') {
+		 replacement = replacement(portion, match);
+		 if (replacement && replacement.nodeType) {
+			 return replacement;
+		 }
+		 return doc.createTextNode(String(replacement));
+	 }
+
+	 var el = typeof wrapper == 'string' ? doc.createElement(wrapper) : wrapper;
+
+		if (el && wrapperClass) {
+		 el.className = wrapperClass;
+	 }
+
+	 replacement = doc.createTextNode(
+		 this.prepareReplacementString(
+			 replacement, portion, match
+		 )
+	 );
+
+	 if (!replacement.data) {
+		 return replacement;
+	 }
+
+	 if (!el) {
+		 return replacement;
+	 }
+
+	 el.appendChild(replacement);
+
+	 return el;
+ },
+
+ replaceMatch: function(match, startPortion, innerPortions, endPortion) {
+
+	 var matchStartNode = startPortion.node;
+	 var matchEndNode = endPortion.node;
+
+	 var precedingTextNode;
+	 var followingTextNode;
+
+	 if (matchStartNode === matchEndNode) {
+
+		 var node = matchStartNode;
+
+		 if (startPortion.indexInNode > 0) {
+			 // Add `before` text node (before the match)
+			 precedingTextNode = doc.createTextNode(node.data.substring(0, startPortion.indexInNode));
+			 node.parentNode.insertBefore(precedingTextNode, node);
+		 }
+
+		 // Create the replacement node:
+		 var newNode = this.getPortionReplacementNode(
+			 endPortion,
+			 match
+		 );
+
+		 node.parentNode.insertBefore(newNode, node);
+
+		 if (endPortion.endIndexInNode < node.length) { // ?????
+			 // Add `after` text node (after the match)
+			 followingTextNode = doc.createTextNode(node.data.substring(endPortion.endIndexInNode));
+			 node.parentNode.insertBefore(followingTextNode, node);
+		 }
+
+		 node.parentNode.removeChild(node);
+
+		 this.reverts.push(function() {
+			 if (precedingTextNode === newNode.previousSibling) {
+				 precedingTextNode.parentNode.removeChild(precedingTextNode);
+			 }
+			 if (followingTextNode === newNode.nextSibling) {
+				 followingTextNode.parentNode.removeChild(followingTextNode);
+			 }
+			 newNode.parentNode.replaceChild(node, newNode);
+		 });
+
+		 return newNode;
+
+	 } else {
+		 // Replace matchStartNode -> [innerMatchNodes...] -> matchEndNode (in that order)
+
+
+		 precedingTextNode = doc.createTextNode(
+			 matchStartNode.data.substring(0, startPortion.indexInNode)
+		 );
+
+		 followingTextNode = doc.createTextNode(
+			 matchEndNode.data.substring(endPortion.endIndexInNode)
+		 );
+
+		 var firstNode = this.getPortionReplacementNode(
+			 startPortion,
+			 match
+		 );
+
+		 var innerNodes = [];
+
+		 for (var i = 0, l = innerPortions.length; i < l; ++i) {
+			 var portion = innerPortions[i];
+			 var innerNode = this.getPortionReplacementNode(
+				 portion,
+				 match
+			 );
+			 portion.node.parentNode.replaceChild(innerNode, portion.node);
+			 this.reverts.push((function(portion, innerNode) {
+				 return function() {
+					 innerNode.parentNode.replaceChild(portion.node, innerNode);
+				 };
+			 }(portion, innerNode)));
+			 innerNodes.push(innerNode);
+		 }
+
+		 var lastNode = this.getPortionReplacementNode(
+			 endPortion,
+			 match
+		 );
+
+		 matchStartNode.parentNode.insertBefore(precedingTextNode, matchStartNode);
+		 matchStartNode.parentNode.insertBefore(firstNode, matchStartNode);
+		 matchStartNode.parentNode.removeChild(matchStartNode);
+
+		 matchEndNode.parentNode.insertBefore(lastNode, matchEndNode);
+		 matchEndNode.parentNode.insertBefore(followingTextNode, matchEndNode);
+		 matchEndNode.parentNode.removeChild(matchEndNode);
+
+		 this.reverts.push(function() {
+			 precedingTextNode.parentNode.removeChild(precedingTextNode);
+			 firstNode.parentNode.replaceChild(matchStartNode, firstNode);
+			 followingTextNode.parentNode.removeChild(followingTextNode);
+			 lastNode.parentNode.replaceChild(matchEndNode, lastNode);
+		 });
+
+		 return lastNode;
+	 }
+ }
+
+};
+
+return exposed;
+
+}));

--- a/src/script/webAudio.ts
+++ b/src/script/webAudio.ts
@@ -13,7 +13,7 @@ export default class WebAudio {
 
     // Process subtitles
     subtitles.forEach(subtitle => {
-      let result = filter.advancedReplaceText(subtitle.innerText);
+      let result = filter.replaceTextResult(subtitle.innerText);
       if (result.modified) {
         filtered = true;
         subtitle.innerText = result.filtered;

--- a/src/script/webConfig.ts
+++ b/src/script/webConfig.ts
@@ -2,14 +2,14 @@ import Config from './lib/config';
 
 export default class WebConfig extends Config {
   static async build(keys?: string[]) {
-    let async_result = await WebConfig.getConfig(keys);
-    let instance = new WebConfig(async_result);
+    let asyncResult = await WebConfig.getConfig(keys);
+    let instance = new WebConfig(asyncResult);
     return instance;
   }
 
   // Call build() to create a new instance
-  constructor(async_param) {
-    super(async_param);
+  constructor(asyncParam) {
+    super(asyncParam);
   }
 
   // Compile words

--- a/src/script/webFilter.ts
+++ b/src/script/webFilter.ts
@@ -139,7 +139,7 @@ export default class WebFilter extends Filter {
 
     // Check for advanced mode on current domain
     this.advanced = this.advancedPage();
-    if (this.advanced) { message.advanced = true; }
+    message.advanced = this.advanced; // Set badge color
     chrome.runtime.sendMessage(message);
 
     // Detect if we should mute audio for the current page

--- a/src/script/webFilter.ts
+++ b/src/script/webFilter.ts
@@ -35,7 +35,7 @@ export default class WebFilter extends Filter {
     return Domain.domainMatch(this.hostname, this.cfg.advancedDomains);
   }
 
-  replaceTextResult(string: string) {
+  replaceTextResult(string: string, stats: boolean = true) {
     let result = {} as any;
     result.original = string;
     result.filtered = filter.replaceText(string);
@@ -62,7 +62,7 @@ export default class WebFilter extends Filter {
           WebAudio.clean(filter, node, filter.subtitleSelector);
         } else {
           // console.log('Added node to filter', node); // DEBUG - Mutation addedNodes
-          if (filter.advanced) {
+          if (filter.advanced && node.parentNode) {
             filter.advancedReplaceText(node);
           } else {
             filter.cleanNode(node);

--- a/src/script/webFilter.ts
+++ b/src/script/webFilter.ts
@@ -46,7 +46,7 @@ export default class WebFilter extends Filter {
   advancedReplaceText(node) {
     filter.wordRegExps.forEach((regExp, index) => {
       // @ts-ignore - External library function
-      window.findAndReplaceDOMText(node, {preset: 'prose', find: regExp, replace: function(portion, match) {
+      findAndReplaceDOMText(node, {preset: 'prose', find: regExp, replace: function(portion, match) {
         return filter.replaceText(match[0]);
       }});
     });
@@ -148,7 +148,7 @@ export default class WebFilter extends Filter {
 
     // Remove profanity from the main document and watch for new nodes
     this.init();
-    this.cleanNode(document);
+    this.advanced ? this.advancedReplaceText(document) : this.cleanNode(document);
     this.updateCounterBadge();
     this.observeNewNodes();
   }

--- a/src/script/webFilter.ts
+++ b/src/script/webFilter.ts
@@ -47,6 +47,7 @@ export default class WebFilter extends Filter {
     filter.wordRegExps.forEach((regExp, index) => {
       // @ts-ignore - External library function
       findAndReplaceDOMText(node, {preset: 'prose', find: regExp, replace: function(portion, match) {
+        // console.log('[APF] Advanced node match:', node.textContent); // DEBUG - Advanced match
         return filter.replaceText(match[0]);
       }});
     });
@@ -97,7 +98,9 @@ export default class WebFilter extends Filter {
     // else { console.log('Forbidden mutation.target node:', mutation.target); } // DEBUG - Mutation target text
   }
 
-  cleanNode(node, mutation: MutationRecord = null) {
+  cleanNode(node) {
+    if (Page.isForbiddenNode(node)) { return false; }
+
     if (node.childElementCount > 0) { // Tree node
       let treeWalker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT);
       while(treeWalker.nextNode()) {
@@ -111,15 +114,15 @@ export default class WebFilter extends Filter {
       }
     } else { // Leaf node
       if (node.nodeName) {
-        if (!Page.isForbiddenNode(node) || node.textContent.trim() != '') {
+        if (node.textContent.trim() != '') {
           let result = this.replaceTextResult(node.textContent);
           if (result.modified) {
-            // console.log('Normal node changed:', result.original, result.filtered); // DEBUG - Mutation node
+            // console.log('[APF] Normal node changed:', result.original, result.filtered); // DEBUG - Mutation node
             node.textContent = result.filtered;
           }
         }
       }
-      // else { console.log('node without nodeName:', node); // Debug
+      // else { console.log('node without nodeName:', node); } // Debug
     }
   }
 

--- a/src/script/webFilter.ts
+++ b/src/script/webFilter.ts
@@ -6,11 +6,11 @@ import WebConfig from './webConfig';
 import './vendor/findAndReplaceDOMText';
 
 interface Message {
-  advanced?: boolean,
-  counter?: number,
-  disabled?: boolean,
-  mute?: boolean,
-  summary?: object
+  advanced?: boolean;
+  counter?: number;
+  disabled?: boolean;
+  mute?: boolean;
+  summary?: object;
 }
 
 export default class WebFilter extends Filter {
@@ -44,7 +44,7 @@ export default class WebFilter extends Filter {
   }
 
   advancedReplaceText(node) {
-    filter.wordRegExps.forEach((regExp, index) => {
+    filter.wordRegExps.forEach((regExp) => {
       // @ts-ignore - External library function
       findAndReplaceDOMText(node, {preset: 'prose', find: regExp, replace: function(portion, match) {
         // console.log('[APF] Advanced node match:', node.textContent); // DEBUG - Advanced match
@@ -134,7 +134,7 @@ export default class WebFilter extends Filter {
     this.hostname = (window.location == window.parent.location) ? document.location.hostname : new URL(document.referrer).hostname;
 
     // Check if the topmost frame is a disabled domain
-    let message = { disabled: this.disabledPage() } as Message;
+    let message: Message = { disabled: this.disabledPage() };
     if (message.disabled) {
       chrome.runtime.sendMessage(message);
       return false;

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -4,13 +4,13 @@ import Page from './built/page';
 describe('Page', function() {
   describe('isForbiddenNode()', function() {
     it('should return true when node is editable', function() {
-      let node = { isContentEditable: true };
-      expect(Page.isForbiddenNode(node)).to.equal(true);
+      expect(Page.isForbiddenNode({ isContentEditable: true })).to.equal(true);
+      expect(Page.isForbiddenNode({ parentNode: { isContentEditable: true }})).to.equal(true);
     });
 
     it('should return false when node is not editable', function() {
-      let node = { isContentEditable: false };
-      expect(Page.isForbiddenNode(node)).to.equal(false);
+      expect(Page.isForbiddenNode({ isContentEditable: false })).to.equal(false);
+      expect(Page.isForbiddenNode({ parentNode: { isContentEditable: false } })).to.equal(false);
     });
 
     it('should return true when node has a parent node and tag is forbidden', function() {
@@ -22,13 +22,16 @@ describe('Page', function() {
     });
 
     it('should return true when node is a forbidden tag', function() {
-      let node = { tagName: 'SCRIPT' };
-      expect(Page.isForbiddenNode(node)).to.equal(true);
+      expect(Page.isForbiddenNode({ tagName: 'SCRIPT' })).to.equal(true);
+    });
+
+    it('should return false when node is not a forbidden tag when advanced mode', function() {
+      let advanced = true;
+      expect(Page.isForbiddenNode({ tagName: 'SCRIPT' }, advanced)).to.equal(false);
     });
 
     it('should return false when node is not a forbidden tag', function() {
-      let node = { tagName: 'HTML' };
-      expect(Page.isForbiddenNode(node)).to.equal(false);
+      expect(Page.isForbiddenNode({ tagName: 'HTML' })).to.equal(false);
     });
   });
 });

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -25,11 +25,6 @@ describe('Page', function() {
       expect(Page.isForbiddenNode({ tagName: 'SCRIPT' })).to.equal(true);
     });
 
-    it('should return false when node is not a forbidden tag when advanced mode', function() {
-      let advanced = true;
-      expect(Page.isForbiddenNode({ tagName: 'SCRIPT' }, advanced)).to.equal(false);
-    });
-
     it('should return false when node is not a forbidden tag', function() {
       expect(Page.isForbiddenNode({ tagName: 'HTML' })).to.equal(false);
     });


### PR DESCRIPTION
Features:
* Removing `document.evaluate` in favor of `TreeWalker`
* Removing all xpath code (Was causing issues with picking up some mutation records)
* Advanced mode now uses `findAndReplaceDOMText`, which is capable of matching text across nodes (Example: #110)

Bugs Fixed:
* Set advanced mode color badge correctly based on the tab

Dev:
* Upgrade TypeScript linter


