### PR TITLE
Fix Typo in Default Config

### DIFF
--- a/src/script/dataMigration.ts
+++ b/src/script/dataMigration.ts
@@ -10,7 +10,7 @@ interface WordOptions {
 export default class DataMigration {
   cfg: WebConfig;
 
-  static readonly newestMigration = '1.2.0'; // Migration required by any version less than/equal to this
+  static readonly newestMigration = '2.1.4'; // Migration required by any version less than this
 
   constructor(config) {
     this.cfg = config;
@@ -46,7 +46,23 @@ export default class DataMigration {
       this.singleWordSubstitution();
     }
 
+    if (isVersionOlder(version, getVersion('2.1.4'))) {
+      migrated = true;
+      this.fixSubExpletiveTypo();
+    }
+
     return migrated;
+  }
+
+  // [2.1.4] - Fix typo in word substitutions
+  fixSubExpletiveTypo() {
+    let cfg = this.cfg;
+    Object.keys(cfg.words).forEach(word => {
+      let wordObj = cfg.words[word] as WordOptions;
+      if (wordObj.sub == 'explative') {
+        wordObj.sub = 'expletive';
+      }
+    });
   }
 
   // [1.0.13] - updateRemoveWordsFromStorage - transition from previous words structure under the hood
@@ -65,8 +81,9 @@ export default class DataMigration {
   }
 
   runImportMigrations() {
-    this.sanitizeWords();
-    this.singleWordSubstitution();
+    this.sanitizeWords(); // 1.1.0
+    this.singleWordSubstitution(); // 1.2.0
+    this.fixSubExpletiveTypo(); // 2.1.4
   }
 
   // [1.1.0] - Downcase and trim each word in the list (NOTE: This MAY result in losing some words)

--- a/src/script/lib/config.ts
+++ b/src/script/lib/config.ts
@@ -79,7 +79,7 @@ export default class Config {
     'bastard': { matchMethod: 1, repeat: true, sub: 'jerk' },
     'bitch': { matchMethod: 1, repeat: true, sub: 'jerk' },
     'cocksucker': { matchMethod: 1, repeat: true, sub: 'idiot' },
-    'cunt': { matchMethod: 1, repeat: true, sub: 'explative' },
+    'cunt': { matchMethod: 1, repeat: true, sub: 'expletive' },
     'dammit': { matchMethod: 1, repeat: false, sub: 'dangit' },
     'damn': { matchMethod: 1, repeat: false, sub: 'dang' },
     'dumbass': { matchMethod: 1, repeat: true, sub: 'idiot' },
@@ -99,8 +99,8 @@ export default class Config {
     'pussy': { matchMethod: 0, repeat: true, sub: 'softie' },
     'shit': { matchMethod: 1, repeat: true, sub: 'crap' },
     'slut': { matchMethod: 1, repeat: true, sub: 'tramp' },
-    'tits': { matchMethod: 1, repeat: true, sub: 'explative' },
-    'twat': { matchMethod: 1, repeat: true, sub: 'explative' },
+    'tits': { matchMethod: 1, repeat: true, sub: 'expletive' },
+    'twat': { matchMethod: 1, repeat: true, sub: 'expletive' },
     'whore': { matchMethod: 1, repeat: true, sub: 'tramp' }
   };
 

--- a/src/script/lib/helper.ts
+++ b/src/script/lib/helper.ts
@@ -48,13 +48,13 @@ export function getVersion(version: string): Version {
   };
 }
 
-// Is the provided version lower than or equal to the minimum version?
+// Is the provided version lower than the minimum version?
 export function isVersionOlder(version: Version, minimum: Version): boolean {
   if (version.major < minimum.major) {
     return true;
   } else if (version.major == minimum.major && version.minor < minimum.minor) {
     return true;
-  } else if (version.major == minimum.major && version.minor == minimum.minor && version.patch <= minimum.patch) {
+  } else if (version.major == minimum.major && version.minor == minimum.minor && version.patch < minimum.patch) {
     return true;
   }
 

--- a/test/lib/helper.spec.js
+++ b/test/lib/helper.spec.js
@@ -31,10 +31,6 @@ describe('Helper', function() {
       expect(isVersionOlder(version, minimum)).to.equal(true);
 
       version = getVersion('1.5.10');
-      minimum = getVersion('1.5.10');
-      expect(isVersionOlder(version, minimum)).to.equal(true);
-
-      version = getVersion('1.5.10');
       minimum = getVersion('1.5.11');
       expect(isVersionOlder(version, minimum)).to.equal(true);
     });
@@ -58,6 +54,10 @@ describe('Helper', function() {
 
       version = getVersion('1.3.0');
       minimum = getVersion('1.2.12');
+      expect(isVersionOlder(version, minimum)).to.equal(false);
+
+      version = getVersion('1.5.10');
+      minimum = getVersion('1.5.10');
       expect(isVersionOlder(version, minimum)).to.equal(false);
 
       version = getVersion('1.5.11');


### PR DESCRIPTION
Fixes: #138 

Adjust `isVersionOlder()` to only match if its less than the compared version.