### PR TITLE
Wordlists, Bulk Word Editor, Domains Refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 
 node_js:
   - "node"
-  - "10"
+  - "14"
 
 before_script:
   - npm install

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:cov": "npm run build:test && nyc --reporter=lcov --reporter=text node_modules/mocha/bin/_mocha",
     "test:debug": "node --inspect-brk node_modules/mocha/bin/_mocha --reporter tap",
     "test:lint": "eslint \"src/**/*.ts\"",
+    "test:lint:tests": "eslint \"test/**/*.spec.js\"",
     "test:nocov": "node_modules/mocha/bin/_mocha",
     "test:types": "tsc --noEmit",
     "test": "npm run test:lint && npm run test:types && npm run test:cov",
@@ -100,6 +101,14 @@
     "rules": {
       "indent": "off",
       "no-console": "warn",
+      "array-bracket-spacing": [
+        "warn",
+        "never"
+      ],
+      "object-curly-spacing": [
+        "warn",
+        "always"
+      ],
       "no-control-regex": [
         "off"
       ],

--- a/src/script/bookmarkletFilter.ts
+++ b/src/script/bookmarkletFilter.ts
@@ -43,13 +43,13 @@ export default class BookmarkletFilter extends Filter {
   advancedReplaceText(node, wordlistId: number, stats = true) {
     filter.wordlists[wordlistId].regExps.forEach((regExp) => {
       // @ts-ignore - External library function
-      findAndReplaceDOMText(node, {preset: 'prose', find: regExp, replace: function(portion, match) {
+      findAndReplaceDOMText(node, { preset: 'prose', find: regExp, replace: function(portion, match) {
         if (portion.index === 0) { // Replace the whole match on the first portion and skip the rest
           return filter.replaceText(match[0], wordlistId, stats);
         } else {
           return '';
         }
-      }});
+      } });
     });
   }
 

--- a/src/script/bookmarkletFilter.ts
+++ b/src/script/bookmarkletFilter.ts
@@ -26,7 +26,6 @@ export default class BookmarkletFilter extends Filter {
   iframe: Location;
   mutePage: boolean;
   summary: Summary;
-  youTubeMutePage: boolean;
 
   constructor() {
     super();

--- a/src/script/dataMigration.ts
+++ b/src/script/dataMigration.ts
@@ -68,9 +68,9 @@ export default class DataMigration {
 
   // [1.0.13] - updateRemoveWordsFromStorage - transition from previous words structure under the hood
   moveToNewWordsStorage() {
-    chrome.storage.sync.get({'words': null}, function(oldWords) {
+    chrome.storage.sync.get({ 'words': null }, function(oldWords) {
       if (oldWords.words) {
-        chrome.storage.sync.set({'_words0': oldWords.words}, function() {
+        chrome.storage.sync.set({ '_words0': oldWords.words }, function() {
           if (!chrome.runtime.lastError) {
             chrome.storage.sync.remove('words', function() {
               // Removed old words
@@ -120,21 +120,21 @@ export default class DataMigration {
   updateDefaultSubs() {
     let cfg = this.cfg;
     let updatedWords = {
-      bastard: {original: 'jerk', update: 'idiot'},
-      bitch: {original: 'jerk', update: 'bench'},
-      cocksucker: {original: 'idiot', update: 'suckup'},
-      cunt: {original: 'explative', update: 'expletive' },
-      fag: {original: 'slur', update: 'gay'},
-      faggot: {original: 'slur', update: 'gay'},
-      fags: {original: 'slur', update: 'gays'},
+      bastard: { original: 'jerk', update: 'idiot' },
+      bitch: { original: 'jerk', update: 'bench' },
+      cocksucker: { original: 'idiot', update: 'suckup' },
+      cunt: { original: 'explative', update: 'expletive' },
+      fag: { original: 'slur', update: 'gay' },
+      faggot: { original: 'slur', update: 'gay' },
+      fags: { original: 'slur', update: 'gays' },
       fuck: { original: 'fudge', update: 'freak' },
-      goddammit: {original: 'goshdangit', update: 'dangit'},
-      jackass: {original: 'idiot', update: 'jerk'},
-      nigga: {original: 'ethnic slur', update: 'bruh'},
-      nigger: {original: 'ethnic slur', update: 'man'},
-      niggers: {original: 'ethnic slurs', update: 'people'},
-      tits: {original: 'explative', update: 'chest'},
-      twat: {original: 'explative', update: 'dumbo'},
+      goddammit: { original: 'goshdangit', update: 'dangit' },
+      jackass: { original: 'idiot', update: 'jerk' },
+      nigga: { original: 'ethnic slur', update: 'bruh' },
+      nigger: { original: 'ethnic slur', update: 'man' },
+      niggers: { original: 'ethnic slurs', update: 'people' },
+      tits: { original: 'explative', update: 'chest' },
+      twat: { original: 'explative', update: 'dumbo' },
     };
 
     Object.keys(updatedWords).forEach(updatedWord => {

--- a/src/script/dataMigration.ts
+++ b/src/script/dataMigration.ts
@@ -13,6 +13,7 @@ export default class DataMigration {
     { version: '2.3.0', name: 'fixSmartWatch', runOnImport: false },
     { version: '2.7.0', name: 'addWordlistsToWords', runOnImport: true },
     { version: '2.7.0', name: 'removeGlobalMatchMethod', runOnImport: true },
+    { version: '2.7.0', name: 'removeOldDomainArrays', runOnImport: true },
   ];
 
   constructor(config) {
@@ -105,6 +106,23 @@ export default class DataMigration {
       });
       cfg.remove('globalMatchMethod');
     }
+  }
+
+  removeOldDomainArrays() {
+    let cfg = this.cfg as any;
+    if (!cfg.domains) { cfg.domains = {}; }
+    let propsToDelete = { advancedDomains: 'adv', disabledDomains: 'disabled', enabledDomains: 'enabled' };
+    Object.keys(propsToDelete).forEach(function(propToDelete) {
+      if (cfg[propToDelete] && Array.isArray(cfg[propToDelete])) {
+        if (cfg[propToDelete].length > 0) {
+          cfg[propToDelete].forEach(function(domain) {
+            if (cfg.domains[domain] == undefined) { cfg.domains[domain] = {}; }
+            cfg.domains[domain][propsToDelete[propToDelete]] = true;
+          });
+        }
+      }
+      delete cfg[propToDelete];
+    });
   }
 
   runImportMigrations() {

--- a/src/script/dataMigration.ts
+++ b/src/script/dataMigration.ts
@@ -85,9 +85,8 @@ export default class DataMigration {
       if (oldWords.words) {
         chrome.storage.sync.set({ '_words0': oldWords.words }, function() {
           if (!chrome.runtime.lastError) {
-            chrome.storage.sync.remove('words', function() {
-              // Removed old words
-            });
+            // Remove old words
+            chrome.storage.sync.remove('words');
           }
         });
       }
@@ -104,7 +103,7 @@ export default class DataMigration {
           word.matchMethod = 3;
         }
       });
-      cfg.removeProp('globalMatchMethod');
+      cfg.remove('globalMatchMethod');
     }
   }
 

--- a/src/script/dataMigration.ts
+++ b/src/script/dataMigration.ts
@@ -12,6 +12,7 @@ export default class DataMigration {
     { version: '2.1.4', name: 'updateDefaultSubs', runOnImport: false },
     { version: '2.3.0', name: 'fixSmartWatch', runOnImport: false },
     { version: '2.7.0', name: 'addWordlistsToWords', runOnImport: true },
+    { version: '2.7.0', name: 'removeGlobalMatchMethod', runOnImport: true },
   ];
 
   constructor(config) {
@@ -91,6 +92,20 @@ export default class DataMigration {
         });
       }
     });
+  }
+
+  removeGlobalMatchMethod() {
+    let cfg = this.cfg;
+    if ((cfg as any).globalMatchMethod !== undefined) {
+      Object.keys(cfg.words).forEach(name => {
+        let word = cfg.words[name];
+        // Move RegExp from 4 to 3
+        if (word.matchMethod === 4) {
+          word.matchMethod = 3;
+        }
+      });
+      cfg.removeProp('globalMatchMethod');
+    }
   }
 
   runImportMigrations() {

--- a/src/script/dataMigration.ts
+++ b/src/script/dataMigration.ts
@@ -10,7 +10,8 @@ export default class DataMigration {
     { version: '1.1.0', name: 'sanitizeWords', runOnImport: true },
     { version: '1.2.0', name: 'singleWordSubstitution', runOnImport: true },
     { version: '2.1.4', name: 'updateDefaultSubs', runOnImport: false },
-    { version: '2.3.0', name: 'fixSmartWatch', runOnImport: false }
+    { version: '2.3.0', name: 'fixSmartWatch', runOnImport: false },
+    { version: '2.7.0', name: 'addWordlistsToWords', runOnImport: true },
   ];
 
   constructor(config) {
@@ -28,6 +29,17 @@ export default class DataMigration {
 
   static migrationNeeded(oldVersion: string): boolean {
     return isVersionOlder(getVersion(oldVersion), getVersion(DataMigration.latestMigration().version));
+  }
+
+  // [2.7.0]
+  addWordlistsToWords() {
+    let cfg = this.cfg as WebConfig;
+    Object.keys(cfg.words).forEach(key => {
+      let word = cfg.words[key];
+      if (!Array.isArray(word.lists)) {
+        word.lists = [];
+      }
+    });
   }
 
   // This will look at the version (from before the update) and perform data migrations if necessary

--- a/src/script/domain.ts
+++ b/src/script/domain.ts
@@ -1,9 +1,42 @@
-import { removeFromArray } from './lib/helper';
+import WebConfig from './webConfig';
 
 export default class Domain {
-  tab: any;
-  url: URL;
-  hostname: string;
+  advanced: boolean;
+  audioWordlistId: number;
+  cfg: DomainCfg;
+  cfgKey: string;
+  disabled: boolean;
+  enabled: boolean;
+  hostname?: string;
+  tab?: any;
+  wordlistId: number;
+
+  static readonly _defaults = {
+    advanced: undefined,
+    audioWordlistId: undefined,
+    disabled: undefined,
+    enabled: undefined,
+    wordlistId: undefined,
+  }
+
+  static readonly _domainCfgDefaults: DomainCfg = {
+    audioList: undefined,
+    wordlist: undefined,
+    adv: undefined,
+    enabled: undefined,
+    disabled: undefined,
+  }
+
+  static byHostname(hostname: string, domains: { [domain: string]: DomainCfg }): Domain {
+    let cfgKey = Domain.findDomainKey(hostname, domains) || hostname;
+    let domain = Domain.byKey(cfgKey, domains);
+    domain.hostname = hostname;
+    return domain;
+  }
+
+  static byKey(key: string, domains: { [domain: string]: DomainCfg }): Domain {
+    return new Domain(key, domains[key]);
+  }
 
   static domainMatch(domain: string, domains: string[]): boolean {
     let result = false;
@@ -19,20 +52,9 @@ export default class Domain {
     return result;
   }
 
-  // If a parent domain (example.com) is included, it will not match all subdomains.
-  // If a subdomain is included, it will match itself and the parent, if present.
-  static removeFromList(domain: string, domains: string[]): string[] {
-    let domainRegex;
-    let newDomainsList = domains;
-
-    for (let x = 0; x < domains.length; x++) {
-      domainRegex = new RegExp('(^|\.)' + domains[x], 'i');
-      if (domainRegex.test(domain)) {
-        newDomainsList = removeFromArray(newDomainsList, domains[x]);
-      }
-    }
-
-    return newDomainsList;
+  static findDomainKey(hostname: string, domains: { [domain: string]: DomainCfg }): string {
+    let sorted = Object.keys(domains).sort((a, b) => { return b.length - a.length; });
+    return sorted.find(key => new RegExp(`(^|.)${key}$`).test(hostname));
   }
 
   static getCurrentTab() {
@@ -44,9 +66,53 @@ export default class Domain {
     });
   }
 
-  async load() {
-    this.tab = await Domain.getCurrentTab();
-    this.url = new URL(this.tab.url);
-    this.hostname = this.url.hostname;
+  static sortedKeys(domains: { [site: string]: DomainCfg }) {
+    return Object.keys(domains).sort(function(a,b) {
+      let domainA = a.match(/\w*\.\w*$/)[0];
+      let domainB = b.match(/\w*\.\w*$/)[0];
+      return domainA < domainB ? -1 : domainA > domainB ? 1 : 0;
+    });
+  }
+
+  constructor(key: string, domainCfg: DomainCfg, saved: boolean = false) {
+    this.cfgKey = key;
+    if (!domainCfg) {
+      this.cfg = Object.assign(Domain._domainCfgDefaults);
+    } else {
+      this.cfg = domainCfg;
+    }
+
+    this.updateFromCfg();
+  }
+
+  // Updates the config from the domain and saves it
+  async save(cfg: WebConfig) {
+    if (cfg.domains) {
+      this.updateCfg();
+
+      if (JSON.stringify(this.cfg) === '{}') { // Nothing to save, so remove it
+        delete cfg.domains[this.cfgKey];
+      } else {
+        cfg.domains[this.cfgKey] = this.cfg;
+      }
+
+      return await cfg.save('domains');
+    }
+  }
+
+  updateCfg() {
+    this.cfg.adv = this.advanced === true ? true : undefined;
+    this.cfg.disabled = this.disabled === true ? true : undefined;
+    this.cfg.enabled = this.enabled === true ? true : undefined;
+    this.cfg.wordlist = this.wordlistId >= 0 ? this.wordlistId : undefined;
+    this.cfg.audioList = this.audioWordlistId >= 0 ? this.audioWordlistId : undefined;
+  }
+
+  updateFromCfg() {
+    this.advanced = this.cfg.adv;
+    this.disabled = this.cfg.disabled;
+    this.enabled = this.cfg.enabled;
+    this.wordlistId = this.cfg.wordlist;
+    this.audioWordlistId = this.cfg.audioList;
   }
 }

--- a/src/script/domain.ts
+++ b/src/script/domain.ts
@@ -11,20 +11,12 @@ export default class Domain {
   tab?: any;
   wordlistId: number;
 
-  static readonly _defaults = {
-    advanced: undefined,
-    audioWordlistId: undefined,
-    disabled: undefined,
-    enabled: undefined,
-    wordlistId: undefined,
-  }
-
   static readonly _domainCfgDefaults: DomainCfg = {
-    audioList: undefined,
-    wordlist: undefined,
     adv: undefined,
-    enabled: undefined,
+    audioList: undefined,
     disabled: undefined,
+    enabled: undefined,
+    wordlist: undefined,
   }
 
   static byHostname(hostname: string, domains: { [domain: string]: DomainCfg }): Domain {
@@ -36,20 +28,6 @@ export default class Domain {
 
   static byKey(key: string, domains: { [domain: string]: DomainCfg }): Domain {
     return new Domain(key, domains[key]);
-  }
-
-  static domainMatch(domain: string, domains: string[]): boolean {
-    let result = false;
-
-    for (let x = 0; x < domains.length; x++) {
-      let domainRegex = new RegExp('(^|\.)' + domains[x], 'i');
-      if (domainRegex.test(domain)) {
-        result = true;
-        break;
-      }
-    }
-
-    return result;
   }
 
   static findDomainKey(hostname: string, domains: { [domain: string]: DomainCfg }): string {
@@ -74,10 +52,11 @@ export default class Domain {
     });
   }
 
-  constructor(key: string, domainCfg: DomainCfg, saved: boolean = false) {
+  constructor(key: string, domainCfg?: DomainCfg) {
     this.cfgKey = key;
+    this.cfg = {};
     if (!domainCfg) {
-      this.cfg = Object.assign(Domain._domainCfgDefaults);
+      Object.assign(this.cfg, Domain._domainCfgDefaults);
     } else {
       this.cfg = domainCfg;
     }

--- a/src/script/eventPage.ts
+++ b/src/script/eventPage.ts
@@ -20,7 +20,7 @@ chrome.runtime.onInstalled.addListener(function(details){
     updateMigrations(details.previousVersion);
 
     // Display update notification
-    chrome.storage.sync.get({showUpdateNotification: true}, function(data) {
+    chrome.storage.sync.get({ showUpdateNotification: true }, function(data) {
       if (data.showUpdateNotification) {
         chrome.notifications.create('extensionUpdate', {
           'type': 'basic',
@@ -65,7 +65,7 @@ chrome.runtime.onMessage.addListener(
 
       // Unmute on page reload
       if (request.clearMute === true && sender.tab != undefined) {
-        let {muted, reason, extensionId} = sender.tab.mutedInfo;
+        let { muted, reason, extensionId } = sender.tab.mutedInfo;
         if (muted && reason == 'extension' && extensionId == chrome.runtime.id) {
           chrome.tabs.update(sender.tab.id, { muted: false });
         }
@@ -185,7 +185,7 @@ chrome.notifications.onClicked.addListener(function(notificationId) {
   switch(notificationId) {
     case 'extensionUpdate':
       chrome.notifications.clear('extensionUpdate');
-      chrome.tabs.create({url: 'https://github.com/richardfrost/AdvancedProfanityFilter/releases'});
+      chrome.tabs.create({ url: 'https://github.com/richardfrost/AdvancedProfanityFilter/releases' });
       break;
   }
 });

--- a/src/script/eventPage.ts
+++ b/src/script/eventPage.ts
@@ -1,6 +1,6 @@
-import WebConfig from './webConfig';
-import Domain from './domain';
 import DataMigration from './dataMigration';
+import Domain from './domain';
+import WebConfig from './webConfig';
 
 ////
 // Actions and messaging
@@ -79,7 +79,7 @@ chrome.runtime.onMessage.addListener(
 //
 // Add selected word/phrase and reload page (unless already present)
 async function processSelection(action: string, selection: string) {
-  let cfg = await WebConfig.build(); // TODO: Only need words here
+  let cfg = await WebConfig.build('words');
   let result = cfg[action](selection);
 
   if (result) {
@@ -88,29 +88,19 @@ async function processSelection(action: string, selection: string) {
   }
 }
 
-// Disable domain and reload page (unless already disabled)
-async function disableDomain(cfg: WebConfig, domain: string, key: string) {
-  if (!cfg[key].includes(domain)) {
-    cfg[key].push(domain);
-    let result = await cfg.save(key);
-    if (!result) { chrome.tabs.reload(); }
+async function toggleDomain(hostname: string, action: string) {
+  let cfg = await WebConfig.build(['domains', 'enabledDomainsOnly']);
+  let domain = Domain.byHostname(hostname, cfg.domains);
+
+  switch(action) {
+    case 'disable':
+      cfg.enabledDomainsOnly ? domain.enabled = !domain.enabled : domain.disabled = !domain.disabled; break;
+    case 'advanced':
+      domain.advanced = !domain.advanced; break;
   }
-}
 
-// Remove all entries that disable the filter for domain
-async function enableDomain(cfg: WebConfig, domain: string, key: string) {
-  let newDomainList = Domain.removeFromList(domain, cfg[key]);
-
-  if (newDomainList.length < cfg[key].length) {
-    cfg[key] = newDomainList;
-    let result = await cfg.save(key);
-    if (!result) { chrome.tabs.reload(); }
-  }
-}
-
-async function toggleDomain(domain: string, key: string) {
-  let cfg = await WebConfig.build([key]);
-  Domain.domainMatch(domain, cfg[key]) ? enableDomain(cfg, domain, key) : disableDomain(cfg, domain, key);
+  let error = await domain.save(cfg);
+  if (!error) { chrome.tabs.reload(); }
 }
 
 async function updateMigrations(previousVersion) {
@@ -170,11 +160,11 @@ chrome.contextMenus.onClicked.addListener(function(info, tab) {
       processSelection('removeWord', info.selectionText); break;
     case 'toggleFilterForDomain': {
       let url = new URL(tab.url);
-      toggleDomain(url.hostname, 'disabledDomains'); break;
+      toggleDomain(url.hostname, 'disable'); break;
     }
     case 'toggleAdvancedModeForDomain': {
       let url = new URL(tab.url);
-      toggleDomain(url.hostname, 'advancedDomains'); break;
+      toggleDomain(url.hostname, 'advanced'); break;
     }
     case 'options':
       chrome.runtime.openOptionsPage(); break;

--- a/src/script/globals.d.ts
+++ b/src/script/globals.d.ts
@@ -22,6 +22,14 @@ interface AudioRules {
   videoSelector?: string;           // [Cue,Watcher] Video selector: (Default: 'video')
 }
 
+interface DomainCfg {
+  adv?: boolean;
+  audioList: number;
+  disabled: boolean;
+  enabled: boolean;
+  wordlist: number;
+}
+
 interface FilteredTextTrackCue extends TextTrackCue {
   filtered: boolean;
   originalText: string;

--- a/src/script/globals.d.ts
+++ b/src/script/globals.d.ts
@@ -61,6 +61,8 @@ interface Version {
 }
 
 interface WordOptions {
+  _filterMethod?: number;  // This should not be stored in the config. Only there for new Word
+  lists?: number[]; // []: disabled, 1: default/text, 2: audio
   matchMethod: number;
   repeat: boolean;
   separators?: boolean;

--- a/src/script/globals.d.ts
+++ b/src/script/globals.d.ts
@@ -47,6 +47,12 @@ interface Migration {
   runOnImport: boolean;
 }
 
+interface ReplaceTextResult {
+  original: string;
+  filtered: string;
+  modified: boolean;
+}
+
 interface Summary {
   [word: string]: {
     filtered: string;

--- a/src/script/globals.d.ts
+++ b/src/script/globals.d.ts
@@ -24,10 +24,10 @@ interface AudioRules {
 
 interface DomainCfg {
   adv?: boolean;
-  audioList: number;
-  disabled: boolean;
-  enabled: boolean;
-  wordlist: number;
+  audioList?: number;
+  disabled?: boolean;
+  enabled?: boolean;
+  wordlist?: number;
 }
 
 interface FilteredTextTrackCue extends TextTrackCue {

--- a/src/script/lib/config.ts
+++ b/src/script/lib/config.ts
@@ -7,7 +7,6 @@ export default class Config {
   defaultWordSeparators: boolean;
   filterMethod: number;
   filterWordList: boolean;
-  globalMatchMethod: number;
   iWordWhitelist: string[];
   preserveCase: boolean;
   preserveFirst: boolean;
@@ -27,14 +26,6 @@ export default class Config {
     remove: 2
   };
 
-  static readonly matchMethods = {
-    exact: 0,
-    partial: 1,
-    whole: 2,
-    'Per-Word': 3,
-    'RegExp': 4
-  };
-
   static readonly _defaults = {
     censorCharacter: '*',
     censorFixedLength: 0,
@@ -44,7 +35,6 @@ export default class Config {
     defaultWordSeparators: false,
     filterMethod: 1, // ['Censor', 'Substitute', 'Remove'];
     filterWordList: true,
-    globalMatchMethod: 3, // ['Exact', 'Partial', 'Whole', 'Per-Word', 'RegExp']
     iWordWhitelist: [],
     preserveCase: true,
     preserveFirst: true,
@@ -94,7 +84,7 @@ export default class Config {
 
   static readonly _allWordlists = ['All Words'];
   static readonly _filterMethodNames = ['Censor', 'Substitute', 'Remove'];
-  static readonly _matchMethodNames = ['Exact', 'Partial', 'Whole', 'Per-Word', 'Regular-Expression'];
+  static readonly _matchMethodNames = ['Exact', 'Partial', 'Whole', 'Regular-Expression'];
   static readonly _maxBytes = 6500;
   static readonly _maxWords = 100;
   static readonly _wordsPattern = /^_words\d+/;

--- a/src/script/lib/config.ts
+++ b/src/script/lib/config.ts
@@ -27,6 +27,9 @@ export default class Config {
   showSummary: boolean;
   showUpdateNotification: boolean;
   substitutionMark: boolean;
+  wordlistId: number;
+  wordlists: string[];
+  wordlistsEnabled: boolean;
   words: { [key: string]: WordOptions };
   wordWhitelist: string[];
   youTubeAutoSubsMin: number;
@@ -74,44 +77,48 @@ export default class Config {
     showSummary: true,
     showUpdateNotification: true,
     substitutionMark: false,
+    wordlistId: 0,
+    wordlists: ['Custom 1', 'Custom 2', 'Custom 3', 'Custom 4', 'Custom 5', 'Custom 6'],
+    wordlistsEnabled: false,
     wordWhitelist: [],
     youTubeAutoSubsMin: 0
   };
 
-  static readonly _defaultWords = {
-    'ass': { matchMethod: 0, repeat: true, separators: false, sub: 'butt' },
-    'asses': { matchMethod: 0, repeat: false, separators: false, sub: 'butts' },
-    'asshole': { matchMethod: 1, repeat: true, separators: false, sub: 'jerk' },
-    'badass': { matchMethod: 1, repeat: true, separators: true, sub: 'cool' },
-    'bastard': { matchMethod: 1, repeat: true, separators: false, sub: 'idiot' },
-    'bitch': { matchMethod: 1, repeat: true, separators: false, sub: 'bench' },
-    'cocksucker': { matchMethod: 1, repeat: true, separators: true, sub: 'suckup' },
-    'cunt': { matchMethod: 1, repeat: true, separators: false, sub: 'expletive' },
-    'dammit': { matchMethod: 1, repeat: false, separators: true, sub: 'dangit' },
-    'damn': { matchMethod: 1, repeat: false, separators: false, sub: 'dang' },
-    'dumbass': { matchMethod: 1, repeat: true, separators: false, sub: 'idiot' },
-    'fag': { matchMethod: 0, repeat: true, separators: false, sub: 'gay' },
-    'faggot': { matchMethod: 1, repeat: true, separators: false, sub: 'gay' },
-    'fags': { matchMethod: 0, repeat: true, separators: false, sub: 'gays' },
-    'fuck': { matchMethod: 1, repeat: true, separators: true, sub: 'freak' },
-    'goddammit': { matchMethod: 1, repeat: true, separators: true, sub: 'dangit' },
-    'hell': { matchMethod: 0, repeat: false, separators: false, sub: 'heck' },
-    'jackass': { matchMethod: 1, repeat: true, separators: true, sub: 'jerk' },
-    'nigga': { matchMethod: 0, repeat: true, separators: false, sub: 'bruh' },
-    'nigger': { matchMethod: 0, repeat: true, separators: false, sub: 'man' },
-    'niggers': { matchMethod: 0, repeat: true, separators: false, sub: 'people' },
-    'piss': { matchMethod: 1, repeat: true, separators: false, sub: 'pee' },
-    'pissed': { matchMethod: 1, repeat: true, separators: false, sub: 'ticked' },
-    'pussies': { matchMethod: 0, repeat: true, separators: false, sub: 'softies' },
-    'pussy': { matchMethod: 0, repeat: true, separators: false, sub: 'softie' },
-    'shit': { matchMethod: 1, repeat: true, separators: false, sub: 'crap' },
-    'slut': { matchMethod: 1, repeat: true, separators: false, sub: 'tramp' },
-    'tits': { matchMethod: 1, repeat: true, separators: false, sub: 'chest' },
-    'twat': { matchMethod: 0, repeat: true, separators: false, sub: 'dumbo' },
-    'twats': { matchMethod: 0, repeat: true, separators: false, sub: 'dumbos' },
-    'whore': { matchMethod: 1, repeat: true, separators: false, sub: 'tramp' }
+  static readonly _defaultWords: { [key: string]: WordOptions } = {
+    'ass': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'butt' },
+    'asses': { lists: [], matchMethod: 0, repeat: false, separators: false, sub: 'butts' },
+    'asshole': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'jerk' },
+    'badass': { lists: [], matchMethod: 1, repeat: true, separators: true, sub: 'cool' },
+    'bastard': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'idiot' },
+    'bitch': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'bench' },
+    'cocksucker': { lists: [], matchMethod: 1, repeat: true, separators: true, sub: 'suckup' },
+    'cunt': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'expletive' },
+    'dammit': { lists: [], matchMethod: 1, repeat: false, separators: true, sub: 'dangit' },
+    'damn': { lists: [], matchMethod: 1, repeat: false, separators: false, sub: 'dang' },
+    'dumbass': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'idiot' },
+    'fag': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'gay' },
+    'faggot': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'gay' },
+    'fags': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'gays' },
+    'fuck': { lists: [], matchMethod: 1, repeat: true, separators: true, sub: 'freak' },
+    'goddammit': { lists: [], matchMethod: 1, repeat: true, separators: true, sub: 'dangit' },
+    'hell': { lists: [], matchMethod: 0, repeat: false, separators: false, sub: 'heck' },
+    'jackass': { lists: [], matchMethod: 1, repeat: true, separators: true, sub: 'jerk' },
+    'nigga': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'bruh' },
+    'nigger': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'man' },
+    'niggers': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'people' },
+    'piss': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'pee' },
+    'pissed': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'ticked' },
+    'pussies': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'softies' },
+    'pussy': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'softie' },
+    'shit': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'crap' },
+    'slut': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'tramp' },
+    'tits': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'chest' },
+    'twat': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'dumbo' },
+    'twats': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'dumbos' },
+    'whore': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'tramp' }
   };
 
+  static readonly _allWordlists = ['All Words'];
   static readonly _filterMethodNames = ['Censor', 'Substitute', 'Remove'];
   static readonly _matchMethodNames = ['Exact', 'Partial', 'Whole', 'Per-Word', 'Regular-Expression'];
   static readonly _maxBytes = 6500;
@@ -131,10 +138,16 @@ export default class Config {
       this.words[str] = options;
       return true;
     } else {
+      let lists = [];
+      if (this.wordlistsEnabled) {
+        lists.push(this.wordlistId);
+      }
+
       this.words[str] = {
         matchMethod: this.defaultWordMatchMethod,
         repeat: this.defaultWordRepeat,
         separators: this.defaultWordSeparators,
+        lists: lists,
         sub: ''
       };
       return true;

--- a/src/script/lib/config.ts
+++ b/src/script/lib/config.ts
@@ -1,39 +1,25 @@
 export default class Config {
-  advancedDomains: string[];
   censorCharacter: string;
   censorFixedLength: number;
-  customAudioSites: { [site: string]: AudioRules[] };
   defaultSubstitution: string;
   defaultWordMatchMethod: number;
   defaultWordRepeat: boolean;
   defaultWordSeparators: boolean;
-  disabledDomains: string[];
-  enabledDomains: string[];
-  enabledDomainsOnly: boolean;
   filterMethod: number;
   filterWordList: boolean;
   globalMatchMethod: number;
   iWordWhitelist: string[];
-  muteAudio: boolean;
-  muteAudioOnly: boolean;
-  muteMethod: number;
-  muteCueRequireShowing: boolean;
-  password: string;
   preserveCase: boolean;
   preserveFirst: boolean;
   preserveLast: boolean;
   showCounter: boolean;
-  showSubtitles: number;
   showSummary: boolean;
-  showUpdateNotification: boolean;
   substitutionMark: boolean;
   wordlistId: number;
   wordlists: string[];
   wordlistsEnabled: boolean;
   words: { [key: string]: WordOptions };
   wordWhitelist: string[];
-  youTubeAutoSubsMin: number;
-  youTubeAutoSubsMax: number;
 
   static readonly filterMethods = {
     censor: 0,
@@ -50,40 +36,26 @@ export default class Config {
   };
 
   static readonly _defaults = {
-    advancedDomains: [],
     censorCharacter: '*',
     censorFixedLength: 0,
-    customAudioSites: null,
     defaultSubstitution: 'censored',
     defaultWordMatchMethod: 0,
     defaultWordRepeat: false,
     defaultWordSeparators: false,
-    disabledDomains: [],
-    enabledDomains: [],
-    enabledDomainsOnly: false,
     filterMethod: 1, // ['Censor', 'Substitute', 'Remove'];
     filterWordList: true,
     globalMatchMethod: 3, // ['Exact', 'Partial', 'Whole', 'Per-Word', 'RegExp']
     iWordWhitelist: [],
-    muteAudio: false, // Filter audio
-    muteAudioOnly: false,
-    muteMethod: 0, // 0: Mute Tab, 1: Video Volume
-    muteCueRequireShowing: true,
-    password: null,
     preserveCase: true,
     preserveFirst: true,
     preserveLast: false,
     showCounter: true,
-    showSubtitles: 0,
     showSummary: true,
-    showUpdateNotification: true,
     substitutionMark: false,
     wordlistId: 0,
     wordlists: ['Custom 1', 'Custom 2', 'Custom 3', 'Custom 4', 'Custom 5', 'Custom 6'],
     wordlistsEnabled: false,
     wordWhitelist: [],
-    youTubeAutoSubsMin: 0,
-    youTubeAutoSubsMax: 0,
   };
 
   static readonly _defaultWords: { [key: string]: WordOptions } = {

--- a/src/script/lib/config.ts
+++ b/src/script/lib/config.ts
@@ -39,7 +39,7 @@ export default class Config {
     showSummary: true,
     substitutionMark: false,
     wordlistId: 0,
-    wordlists: ['Custom 1', 'Custom 2', 'Custom 3', 'Custom 4', 'Custom 5', 'Custom 6'],
+    wordlists: ['Wordlist 1', 'Wordlist 2', 'Wordlist 3', 'Wordlist 4', 'Wordlist 5', 'Wordlist 6'],
     wordlistsEnabled: false,
     wordWhitelist: [],
   };

--- a/src/script/lib/config.ts
+++ b/src/script/lib/config.ts
@@ -80,9 +80,6 @@ export default class Config {
 
   static readonly _filterMethodNames = ['Censor', 'Substitute', 'Remove'];
   static readonly _matchMethodNames = ['Exact', 'Partial', 'Whole', 'Regular-Expression'];
-  static readonly _maxBytes = 6500;
-  static readonly _maxWords = 100;
-  static readonly _wordsPattern = /^_words\d+/;
 
   constructor(data: object = {}) {
     Object.assign(this, Config._defaults, data);

--- a/src/script/lib/config.ts
+++ b/src/script/lib/config.ts
@@ -20,11 +20,7 @@ export default class Config {
   words: { [key: string]: WordOptions };
   wordWhitelist: string[];
 
-  static readonly filterMethods = {
-    censor: 0,
-    substitute: 1,
-    remove: 2
-  };
+  static readonly _allWordlists = ['All Words'];
 
   static readonly _defaults = {
     censorCharacter: '*',
@@ -79,10 +75,9 @@ export default class Config {
     'tits': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'chest' },
     'twat': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'dumbo' },
     'twats': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'dumbos' },
-    'whore': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'tramp' }
+    'whore': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'tramp' },
   };
 
-  static readonly _allWordlists = ['All Words'];
   static readonly _filterMethodNames = ['Censor', 'Substitute', 'Remove'];
   static readonly _matchMethodNames = ['Exact', 'Partial', 'Whole', 'Regular-Expression'];
   static readonly _maxBytes = 6500;

--- a/src/script/lib/filter.ts
+++ b/src/script/lib/filter.ts
@@ -14,7 +14,6 @@ export default class Filter {
     this.counter = 0;
     this.iWhitelist = [];
     this.whitelist = [];
-    this.wordlistId = 0;
     this.wordlists = {};
   }
 
@@ -79,8 +78,8 @@ export default class Filter {
 
   init(wordlistId: number | false = false) {
     this.iWhitelist = this.cfg.iWordWhitelist;
-    this.wordlistId = this.cfg.wordlistId;
     this.whitelist = this.cfg.wordWhitelist;
+    if (this.wordlistId === undefined) { this.wordlistId = this.cfg.wordlistId || 0; }
     this.buildWordlist(wordlistId);
   }
 

--- a/src/script/lib/filter.ts
+++ b/src/script/lib/filter.ts
@@ -214,4 +214,14 @@ export default class Filter {
 
     return str;
   }
+
+  replaceTextResult(str: string, wordlistId: (number | false) = false, stats: boolean = true): ReplaceTextResult {
+    let result: ReplaceTextResult = {
+      original: str,
+      filtered: this.replaceText(str, wordlistId, stats),
+      modified: false
+    };
+    result.modified = (result.filtered != str);
+    return result;
+  }
 }

--- a/src/script/lib/globals.d.ts
+++ b/src/script/lib/globals.d.ts
@@ -76,7 +76,7 @@ interface Version {
 
 interface WordOptions {
   _filterMethod?: number;  // This should not be stored in the config. Only there for new Word
-  lists?: number[]; // []: disabled, 1: default/text, 2: audio
+  lists?: number[];
   matchMethod: number;
   repeat: boolean;
   separators?: boolean;

--- a/src/script/lib/word.ts
+++ b/src/script/lib/word.ts
@@ -52,8 +52,7 @@ export default class Word {
   constructor(word: string, options: WordOptions, cfg: Config) {
     this.value = word;
     this.lists = options.lists || [];
-    this.matchMethod = cfg.globalMatchMethod === 3 ? options.matchMethod : cfg.globalMatchMethod;
-    if (this.matchMethod === undefined) { this.matchMethod = cfg.defaultWordMatchMethod; }
+    this.matchMethod = options.matchMethod || cfg.defaultWordMatchMethod;
     this.matchRepeated = options.repeat === undefined ? cfg.defaultWordRepeat : options.repeat;
     this.matchSeparators = options.separators === undefined ? cfg.defaultWordSeparators : options.separators;
     this.sub = options.sub === undefined ? cfg.defaultSubstitution : options.sub;

--- a/src/script/lib/word.ts
+++ b/src/script/lib/word.ts
@@ -1,14 +1,17 @@
+import Config from './config';
+
 export default class Word {
+  _filterMethod: number;
   escaped: string;
+  lists: number[];
   matchMethod: number;
   matchRepeated: boolean;
   matchSeparators: boolean;
+  regExp: RegExp;
   sub: string;
   unicode: boolean;
   value: string;
 
-  private static readonly _defaultFilterOptions = { filterMethod: 1, globalMatchMethod: 3 }
-  private static readonly _defaultWordOptions = { matchMethod: 0, repeat: false, separators: false, sub: 'censored' };
   private static readonly _edgePunctuationRegExp = /(^[,.'"!?%$]|[,.'"!?%$]$)/;
   private static readonly _escapeRegExp = /[\/\\^$*+?.()|[\]{}]/g;
   private static readonly _unicodeRegExp = /[^\u0000-\u00ff]/;
@@ -16,13 +19,6 @@ export default class Word {
   static readonly nonWordRegExp = new RegExp('^\\s*[^\\w]+\\s*$', 'g');
   static readonly separatorsRegExp = '[-_ ]*';
   static readonly whitespaceRegExp = /^\s+$/;
-
-  static all = [];
-  static defaultWordOptions = Word._defaultWordOptions;
-  static filterMethod = Word._defaultFilterOptions.filterMethod;
-  static globalMatchMethod = Word._defaultFilterOptions.globalMatchMethod;
-  static list = [];
-  static regExps = [];
 
   static allLowerCase(string: string): boolean {
     return string.toLowerCase() === string;
@@ -53,50 +49,23 @@ export default class Word {
     return str.replace(Word._escapeRegExp, '\\$&');
   }
 
-  static find(value: string|number): Word {
-    if (typeof value === 'string') {
-      return Word.all[Word.list.indexOf(value)];
-    } else if (typeof value === 'number') {
-      return Word.all[value];
-    }
-  }
-
-  static initWords(words, filterOptions: any = {}, wordDefaults = {}) {
-    // Sort the words array by longest (most-specific) first
-    Word.all = [];
-    Word.list = [];
-    Word.regExps = [];
-    filterOptions = Object.assign(Word._defaultFilterOptions, filterOptions);
-    Word.filterMethod = filterOptions.filterMethod;
-    // Special regexp for "Remove" filter, uses per-word matchMethods
-    Word.globalMatchMethod = Word.filterMethod === 2 ? Word.globalMatchMethod = 3 : filterOptions.globalMatchMethod;
-    Word.defaultWordOptions = Object.assign(Word._defaultWordOptions, wordDefaults);
-
-    Word.list = Object.keys(words).sort((a, b) => {
-      return b.length - a.length;
-    });
-
-    Word.list.forEach(word => {
-      let instance = new Word(word, words[word]);
-      Word.all.push(instance);
-      Word.regExps.push(instance.buildRegexp());
-    });
-  }
-
-  constructor(word: string, options: WordOptions) {
+  constructor(word: string, options: WordOptions, cfg: Config) {
     this.value = word;
-    this.matchMethod = Word.globalMatchMethod === 3 ? options.matchMethod : Word.globalMatchMethod;
-    this.matchRepeated = options.repeat === undefined ? Word.defaultWordOptions.repeat : options.repeat;
-    this.matchSeparators = options.separators === undefined ? Word.defaultWordOptions.separators : options.separators;
-    this.sub = options.sub == null ? Word.defaultWordOptions.sub : options.sub;
+    this.lists = options.lists || [];
+    this.matchMethod = cfg.globalMatchMethod === 3 ? options.matchMethod : cfg.globalMatchMethod;
+    if (this.matchMethod === undefined) { this.matchMethod = cfg.defaultWordMatchMethod; }
+    this.matchRepeated = options.repeat === undefined ? cfg.defaultWordRepeat : options.repeat;
+    this.matchSeparators = options.separators === undefined ? cfg.defaultWordSeparators : options.separators;
+    this.sub = options.sub === undefined ? cfg.defaultSubstitution : options.sub;
+    this._filterMethod = options._filterMethod === undefined ? cfg.filterMethod : options._filterMethod;
     this.unicode = Word.containsDoubleByte(word);
-    if (this.matchMethod === undefined) { Word.defaultWordOptions.matchMethod; }
     this.escaped = Word.escapeRegExp(this.value);
+    this.regExp = this.buildRegExp();
   }
 
   // Word must match exactly (not sub-string)
   // /\bword\b/gi
-  buildRegexp(): RegExp {
+  buildRegExp(): RegExp {
     let word = this;
     try {
       switch(word.matchMethod) {
@@ -104,7 +73,7 @@ export default class Word {
           // Filter Method: Remove
           // Match entire word that contains sub-string and surrounding whitespace
           // /\s?\bword\b\s?/gi
-          if (Word.filterMethod === 2) { // Remove method
+          if (word._filterMethod === 2) { // Remove method
             if (word.unicode) {
               // Work around for lack of word boundary support for unicode characters
               // /(^|[\s.,'"+!?|-])(word)([\s.,'"+!?|-]+|$)/giu
@@ -141,7 +110,7 @@ export default class Word {
           return new RegExp(word.value, word.regexOptions());
         case 1: // Partial: Match any part of a word (sub-string)
         default:
-          if (Word.filterMethod === 2) { // Filter Method: Remove
+          if (word._filterMethod === 2) { // Filter Method: Remove
             // Match entire word that contains sub-string and surrounding whitespace
             // /\s?\b[\w-]*word[\w-]*\b\s?/gi
             if (word.unicode) {

--- a/src/script/lib/wordlist.ts
+++ b/src/script/lib/wordlist.ts
@@ -1,0 +1,39 @@
+import Word from './word';
+import Config from './config';
+
+export default class Wordlist {
+  all: Word[];
+  list: string[];
+  regExps: RegExp[];
+
+  constructor(cfg: Config, wordlistId: number) {
+    let self = this;
+    this.all = [];
+    this.list = [];
+    this.regExps = [];
+
+    // Sort the words array by longest (most-specific) first
+    let sorted = Object.keys(cfg.words).sort((a, b) => {
+      return b.length - a.length;
+    });
+
+    // Process list of words
+    sorted.forEach(wordStr => {
+      // wordlistId = 0 includes all words
+      if (wordlistId === 0 || !Array.isArray(cfg.words[wordStr].lists) || cfg.words[wordStr].lists.includes(wordlistId)) {
+        self.list.push(wordStr);
+        let word = new Word(wordStr, cfg.words[wordStr], cfg);
+        self.all.push(word);
+        self.regExps.push(word.regExp);
+      }
+    });
+  }
+
+  find(value: string|number): Word {
+    if (typeof value === 'string') {
+      return this.all[this.list.indexOf(value)];
+    } else if (typeof value === 'number') {
+      return this.all[value];
+    }
+  }
+}

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -897,7 +897,7 @@ export default class OptionPage {
       return false;
     }
 
-    this.populateWordsList();
+    this.populateOptions();
   }
 
   showSupportedAudioSites() {

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -103,6 +103,7 @@ export default class OptionPage {
 
   bulkEditorAddRow(word: string = '', data: WordOptions | undefined = undefined) {
     let table = document.querySelector('#bulkWordEditorModal table#bulkEditorTable') as HTMLTableElement;
+    let tbody = table.querySelector('tbody') as HTMLTableSectionElement;
     let wordlistCells = [];
     if (data === undefined) {
       data = {
@@ -115,7 +116,7 @@ export default class OptionPage {
     }
 
     // Build row
-    let row = table.insertRow();
+    let row = tbody.insertRow();
     row.classList.add('bulkWordRow');
     let cellRemoveRow = row.insertCell(0);
     let cellWord = row.insertCell(1);
@@ -1094,7 +1095,7 @@ export default class OptionPage {
     this.cfg.wordlists.forEach((wordlist, i) => { thead += `<th><label><input type="checkbox" class="wordlistHeader" data-col="${i + 1}"><span> ${wordlist}</span></label></th>`; });
     thead += '</tr></thead>';
     title.textContent = 'Bulk Word Editor';
-    tableContainer.innerHTML = `<table id="bulkEditorTable" class="w3-table-all w3-tiny">${thead}</table>`;
+    tableContainer.innerHTML = `<table id="bulkEditorTable" class="w3-table-all w3-tiny w3-hoverable">${thead}<tbody></tbody></table>`;
 
     // Store the select list for match method (used in each row)
     option._bulkWordMatchMethodHTML = '<select>';

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -377,11 +377,8 @@ export default class OptionPage {
     let showCounter = document.getElementById('showCounter') as HTMLInputElement;
     let showSummary = document.getElementById('showSummary') as HTMLInputElement;
     let showUpdateNotification = document.getElementById('showUpdateNotification') as HTMLInputElement;
-    let globalMatchMethodSelect = document.getElementById('globalMatchMethodSelect') as HTMLSelectElement;
     let filterWordList = document.getElementById('filterWordList') as HTMLInputElement;
     selectedFilter.checked = true;
-    dynamicList(WebConfig._matchMethodNames.slice(0, -1), 'globalMatchMethodSelect');
-    globalMatchMethodSelect.selectedIndex = this.cfg.globalMatchMethod;
     showCounter.checked = this.cfg.showCounter;
     showSummary.checked = this.cfg.showSummary;
     showUpdateNotification.checked = this.cfg.showUpdateNotification;
@@ -412,7 +409,7 @@ export default class OptionPage {
     let defaultWordSubstitution = document.getElementById('defaultWordSubstitutionText') as HTMLInputElement;
     defaultWordSubstitution.value = this.cfg.defaultSubstitution;
     let defaultWordMatchMethodSelectHTML = '';
-    for(let i = 0; i < WebConfig._matchMethodNames.slice(0,-2).length; i++) {
+    for(let i = 0; i < WebConfig._matchMethodNames.slice(0,-1).length; i++) {
       defaultWordMatchMethodSelectHTML += '<option value="'+WebConfig._matchMethodNames[i]+'">'+WebConfig._matchMethodNames[i]+'</option>';
     }
     defaultWordMatchMethodSelect.innerHTML = defaultWordMatchMethodSelectHTML;
@@ -695,7 +692,6 @@ export default class OptionPage {
     let defaultWordMatchMethodSelect = document.getElementById('defaultWordMatchMethodSelect') as HTMLSelectElement;
     let defaultWordRepeat = document.getElementById('defaultWordRepeat') as HTMLInputElement;
     let defaultWordSeparators = document.getElementById('defaultWordSeparators') as HTMLInputElement;
-    let globalMatchMethodSelect = document.getElementById('globalMatchMethodSelect') as HTMLSelectElement;
     let preserveCase = document.getElementById('preserveCase') as HTMLInputElement;
     let preserveFirst = document.getElementById('preserveFirst') as HTMLInputElement;
     let preserveLast = document.getElementById('preserveLast') as HTMLInputElement;
@@ -717,7 +713,6 @@ export default class OptionPage {
     self.cfg.defaultWordMatchMethod = defaultWordMatchMethodSelect.selectedIndex;
     self.cfg.defaultWordRepeat = defaultWordRepeat.checked;
     self.cfg.defaultWordSeparators = defaultWordSeparators.checked;
-    self.cfg.globalMatchMethod = globalMatchMethodSelect.selectedIndex;
     self.cfg.preserveCase = preserveCase.checked;
     self.cfg.preserveFirst = preserveFirst.checked;
     self.cfg.preserveLast = preserveLast.checked;
@@ -948,19 +943,16 @@ export default class OptionPage {
       case 0: // Censor
         OptionPage.show(document.getElementById('censorSettings'));
         OptionPage.hide(document.getElementById('substitutionSettings'));
-        OptionPage.show(document.getElementById('globalMatchMethod'));
         OptionPage.hide(document.getElementById('wordSubstitution'));
         break;
       case 1: // Substitution
         OptionPage.hide(document.getElementById('censorSettings'));
         OptionPage.show(document.getElementById('substitutionSettings'));
-        OptionPage.show(document.getElementById('globalMatchMethod'));
         OptionPage.show(document.getElementById('wordSubstitution'));
         break;
       case 2: // Remove
         OptionPage.hide(document.getElementById('censorSettings'));
         OptionPage.hide(document.getElementById('substitutionSettings'));
-        OptionPage.hide(document.getElementById('globalMatchMethod'));
         OptionPage.hide(document.getElementById('wordSubstitution'));
         break;
     }
@@ -1039,7 +1031,6 @@ document.getElementById('censorFixedLengthSelect').addEventListener('change', e 
 document.getElementById('defaultWordMatchMethodSelect').addEventListener('change', e => { option.saveOptions(e); });
 document.getElementById('defaultWordRepeat').addEventListener('click', e => { option.saveOptions(e); });
 document.getElementById('defaultWordSeparators').addEventListener('click', e => { option.saveOptions(e); });
-document.getElementById('globalMatchMethodSelect').addEventListener('change', e => { option.saveOptions(e); });
 document.getElementById('preserveCase').addEventListener('click', e => { option.saveOptions(e); });
 document.getElementById('preserveFirst').addEventListener('click', e => { option.saveOptions(e); });
 document.getElementById('preserveLast').addEventListener('click', e => { option.saveOptions(e); });

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -220,8 +220,12 @@ export default class OptionPage {
       }
     });
 
-    let error = await option.cfg.save('words');
-    error ? OptionPage.showErrorModal('Failed to save.') : OptionPage.showStatusModal('Words saved successfully.');
+    if (await option.cfg.save('words')) {
+      OptionPage.showErrorModal('Failed to save.');
+    } else {
+      OptionPage.closeModal('bulkWordEditorModal');
+      OptionPage.showStatusModal('Words saved successfully.');
+    }
   }
 
   bulkEditorWordlistCheckbox(event) {

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -427,7 +427,7 @@ export default class OptionPage {
     let domainCfg;
     if (!key) { // New record
       OptionPage.disableBtn(domainRemoveBtn);
-      domainCfg = Object.assign(Domain._domainCfgDefaults);
+      domainCfg = Object.assign({}, Domain._domainCfgDefaults);
     } else { // Existing record
       OptionPage.enableBtn(domainRemoveBtn);
       domainCfg = this.cfg.domains[domainsSelect.value];
@@ -860,7 +860,7 @@ export default class OptionPage {
         enabled: domainEnabledCheck.checked,
         wordlist: wordlist,
       };
-      let domain = new Domain(newKey, newDomainCfg, false);
+      let domain = new Domain(newKey, newDomainCfg);
       let error = await domain.save(this.cfg);
 
       if (error) {

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -156,14 +156,14 @@ export default class OptionPage {
     // Build row
     let row = table.insertRow();
     row.classList.add('bulkWordRow');
-    let cellDeleteWord = row.insertCell(0);
+    let cellRemoveRow = row.insertCell(0);
     let cellWord = row.insertCell(1);
     let cellSub = row.insertCell(2);
     let cellMatchMethod = row.insertCell(3);
     let cellRepeat = row.insertCell(4);
     let cellSeparators = row.insertCell(5);
     option.cfg.wordlists.forEach((wordlist, index) => { wordlistCells.push(row.insertCell(index + 6)); });
-    cellDeleteWord.innerHTML = '<button>X</button>';
+    cellRemoveRow.innerHTML = '<button>X</button>';
     cellWord.innerHTML = '<input type="text" class="bulkAddWordText">';
     cellSub.innerHTML = '<input type="text">';
     cellMatchMethod.innerHTML = option._bulkWordMatchMethodHTML;
@@ -174,6 +174,7 @@ export default class OptionPage {
     });
 
     // Populate data
+    cellRemoveRow.querySelector('button').addEventListener('click', e => { option.bulkEditorRemoveRow(e); });
     (cellWord.querySelector('input') as HTMLInputElement).value = word;
     (cellSub.querySelector('input') as HTMLInputElement).value = data.sub;
     (cellMatchMethod.querySelector('select') as HTMLSelectElement).selectedIndex = data.matchMethod;

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -419,14 +419,17 @@ export default class OptionPage {
     let domainEnabledCheck = document.getElementById('domainEnabledCheck') as HTMLInputElement;
     let domainWordlistSelect = document.getElementById('domainWordlistSelect') as HTMLSelectElement;
     let domainAudioWordlistSelect = document.getElementById('domainAudioWordlistSelect') as HTMLSelectElement;
+    let domainRemoveBtn = document.getElementById('domainRemove') as HTMLButtonElement;
 
     let key = domainsSelect.value;
     domainText.value = key;
 
     let domainCfg;
     if (!key) { // New record
+      OptionPage.disableBtn(domainRemoveBtn);
       domainCfg = Object.assign(Domain._domainCfgDefaults);
     } else { // Existing record
+      OptionPage.enableBtn(domainRemoveBtn);
       domainCfg = this.cfg.domains[domainsSelect.value];
     }
 

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -912,7 +912,7 @@ export default class OptionPage {
     contentLeft.innerHTML = `<ul>${sites.join('\n')}</ul>`;
     contentRight.innerHTML = `
       <h4 class="sectionHeader">Site Config</h4>
-      <textarea class="w3-input w3-border w3-card" style="width:375px;height:400px;font-size:11px;" spellcheck="false" readonly>${JSON.stringify(WebAudio.sites, null, 2)}</textarea>
+      <textarea class="w3-input w3-border w3-card" spellcheck="false" readonly>${JSON.stringify(WebAudio.sites, null, 2)}</textarea>
     `;
     OptionPage.openModal('supportedAudioSitesModal');
   }

--- a/src/script/popup.ts
+++ b/src/script/popup.ts
@@ -240,15 +240,15 @@ class Popup {
 // Listen for data updates from filter
 chrome.runtime.onMessage.addListener((request: Message, sender, sendResponse) => {
   if (request.summary) {
-    chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+    chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
       if (sender.tab.id == tabs[0].id) popup.populateSummary(request);
     });
   }
 });
 
 // Initial data request
-chrome.tabs.query({active: true, currentWindow: true}, tabs => {
-  chrome.tabs.sendMessage(tabs[0].id, {popup: true});
+chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+  chrome.tabs.sendMessage(tabs[0].id, { popup: true });
 });
 
 let popup = new Popup;

--- a/src/script/popup.ts
+++ b/src/script/popup.ts
@@ -1,9 +1,11 @@
 import { dynamicList, escapeHTML } from './lib/helper';
+import WebAudio from './webAudio';
 import WebConfig from './webConfig';
 import Domain from './domain';
 
 class Popup {
   cfg: WebConfig;
+  audioSiteKeys: string[];
   domain: Domain;
   filterMethodContainer: Element;
   filterToggleProp: string;
@@ -14,6 +16,7 @@ class Popup {
   static readonly _disabledPages = new RegExp('(^chrome:|^about:|^[a-zA-Z]*-extension:)', 'i');
   static readonly _requiredConfig =  [
     'audioWordlistId',
+    'customAudioSites',
     'domains',
     'enabledDomainsOnly',
     'filterMethod',
@@ -89,11 +92,14 @@ class Popup {
       dynamicList(wordlists, wordlistSelect.id);
       wordlistSelect.selectedIndex = wordlistIndex;
       if (popup.cfg.muteAudio) {
-        let audioWordlistIndex = popup.domain.audioWordlistId >= 0 ? popup.domain.audioWordlistId + 1 : 0;
-        dynamicList(wordlists, audioWordlistSelect.id);
-        audioWordlistSelect.selectedIndex = audioWordlistIndex;
-        let audioWordlistContainer = document.getElementById('audioWordlistContainer') as HTMLElement;
-        Popup.show(audioWordlistContainer);
+        popup.audioSiteKeys = Object.keys(Object.assign({}, WebAudio.sites, popup.cfg.customAudioSites));
+        if (popup.audioSiteKeys.includes(popup.domain.cfgKey)) {
+          let audioWordlistIndex = popup.domain.audioWordlistId >= 0 ? popup.domain.audioWordlistId + 1 : 0;
+          dynamicList(wordlists, audioWordlistSelect.id);
+          audioWordlistSelect.selectedIndex = audioWordlistIndex;
+          let audioWordlistContainer = document.getElementById('audioWordlistContainer') as HTMLElement;
+          Popup.show(audioWordlistContainer);
+        }
       }
       Popup.show(wordListContainer);
     }

--- a/src/script/webAudio.ts
+++ b/src/script/webAudio.ts
@@ -51,7 +51,7 @@ export default class WebAudio {
       this.supportedPage = true;
       if (filter.hostname == 'www.youtube.com') { this.youTube = true; }
       if (!Array.isArray(this.rules)) {
-        this.rules = [ this.rules ];
+        this.rules = [this.rules];
       }
 
       this.supportedNode = this.buildSupportedNodeFunction();
@@ -69,7 +69,7 @@ export default class WebAudio {
   }
 
   static readonly sites: { [site: string]: AudioRules[] } = {
-    'abc.com': [ { mode: 'element', className: 'akamai-caption-text', tagName: 'DIV' } ],
+    'abc.com': [{ mode: 'element', className: 'akamai-caption-text', tagName: 'DIV' }],
     'www.amazon.com': [
       {
         mode: 'watcher',
@@ -85,34 +85,34 @@ export default class WebAudio {
       { mode: 'element', className: 'ttr-container', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' },
       { mode: 'cue', videoCueLanguage: 'en', videoSelector: 'video' }
     ],
-    'www.att.tv': [ { mode: 'cue', videoSelector: 'video#quickplayPlayer' } ],
-    'www.attwatchtv.com': [ { mode: 'cue', videoSelector: 'video#quickplayPlayer' } ],
-    'www.cbs.com': [ { mode: 'cue', videoCueLanguage: 'en', videoCueRequireShowing: false } ],
+    'www.att.tv': [{ mode: 'cue', videoSelector: 'video#quickplayPlayer' }],
+    'www.attwatchtv.com': [{ mode: 'cue', videoSelector: 'video#quickplayPlayer' }],
+    'www.cbs.com': [{ mode: 'cue', videoCueLanguage: 'en', videoCueRequireShowing: false }],
     'www.dishanywhere.com': [
       { mode: 'element', className: 'bmpui-ui-subtitle-label', tagName: 'SPAN' },
       { mode: 'element', className: 'bmpui-subtitle-region-container', subtitleSelector: 'div.bmpui-container-wrapper > span.bmpui-ui-subtitle-label', tagName: 'div' }
     ],
-    'www.disneyplus.com': [ { mode: 'cue', videoSelector: 'video.btm-media-client-element' } ],
-    'www.fox.com': [ { mode: 'element', className: 'jw-text-track-container', subtitleSelector: 'div.jw-text-track-cue', tagName: 'DIV' } ],
-    'www.hulu.com': [ { mode: 'element', className: 'caption-text-box', subtitleSelector: 'p', tagName: 'DIV' } ],
+    'www.disneyplus.com': [{ mode: 'cue', videoSelector: 'video.btm-media-client-element' }],
+    'www.fox.com': [{ mode: 'element', className: 'jw-text-track-container', subtitleSelector: 'div.jw-text-track-cue', tagName: 'DIV' }],
+    'www.hulu.com': [{ mode: 'element', className: 'caption-text-box', subtitleSelector: 'p', tagName: 'DIV' }],
     'www.nbc.com': [
       { mode: 'element', className: 'ttr-line', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' },
       { mode: 'cue', videoCueLanguage: 'en' }
     ],
-    'www.netflix.com': [ { mode: 'element', className: 'player-timedtext-text-container', subtitleSelector: 'span', tagName: 'DIV' } ],
-    'www.philo.com': [ { mode: 'cue' } ],
+    'www.netflix.com': [{ mode: 'element', className: 'player-timedtext-text-container', subtitleSelector: 'span', tagName: 'DIV' }],
+    'www.philo.com': [{ mode: 'cue' }],
     'app.plex.tv': [
       { mode: 'element', dataPropPresent: 'dialogueId', subtitleSelector: 'span > span', tagName: 'DIV' },
       { mode: 'element', containsSelector: 'div[data-dialogue-id]', subtitleSelector: 'span > span', tagName: 'DIV' }
     ],
-    'www.sonycrackle.com': [ { mode: 'text', parentSelector: 'div.clpp-subtitles-container' } ],
-    'play.stan.com.au': [ { mode: 'text', parentSelector: 'div.clpp-subtitles-container' } ],
-    'www.syfy.com': [ { mode: 'element', className: 'ttr-line', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' } ],
-    'www.tntdrama.com': [ { mode: 'cue', videoCueLanguage: 'en', videoSelector: 'video.top-media-element' } ],
-    'www.universalkids.com': [ { mode: 'element', subtitleSelector: 'div.gwt-HTML', tagName: 'DIV' } ],
-    'www.usanetwork.com': [ { mode: 'element', className: 'ttr-line', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' } ],
-    'www.vudu.com': [ { mode: 'element', subtitleSelector: 'span.subtitles', tagName: 'DIV' } ],
-    'www.youtube.com': [ { mode: 'element', className: 'caption-window', subtitleSelector: 'span.ytp-caption-segment', tagName: 'DIV' } ]
+    'www.sonycrackle.com': [{ mode: 'text', parentSelector: 'div.clpp-subtitles-container' }],
+    'play.stan.com.au': [{ mode: 'text', parentSelector: 'div.clpp-subtitles-container' }],
+    'www.syfy.com': [{ mode: 'element', className: 'ttr-line', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' }],
+    'www.tntdrama.com': [{ mode: 'cue', videoCueLanguage: 'en', videoSelector: 'video.top-media-element' }],
+    'www.universalkids.com': [{ mode: 'element', subtitleSelector: 'div.gwt-HTML', tagName: 'DIV' }],
+    'www.usanetwork.com': [{ mode: 'element', className: 'ttr-line', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' }],
+    'www.vudu.com': [{ mode: 'element', subtitleSelector: 'span.subtitles', tagName: 'DIV' }],
+    'www.youtube.com': [{ mode: 'element', className: 'caption-window', subtitleSelector: 'span.ytp-caption-segment', tagName: 'DIV' }]
   };
 
   buildSupportedNodeFunction(): Function {

--- a/src/script/webAudio.ts
+++ b/src/script/webAudio.ts
@@ -77,7 +77,7 @@ export default class WebAudio {
         parentSelector: 'div.webPlayer div.persistentPanel',
         showSubtitles: 0,
         simpleUnmute: true,
-        subtitleSelector: 'div.webPlayer div.persistentPanel > div > div > div > p > span > span',
+        subtitleSelector: 'div.webPlayerContainer div span > span',
         videoSelector: 'div.webPlayerElement video[src]'
       }
     ],

--- a/src/script/webAudio.ts
+++ b/src/script/webAudio.ts
@@ -16,6 +16,7 @@ export default class WebAudio {
   unmuteDelay: number;
   volume: number;
   watcherRuleIds: number[];
+  wordlistId: number;
   youTube: boolean;
   youTubeAutoSubsMin: number;
 
@@ -38,6 +39,7 @@ export default class WebAudio {
     }
     this.unmuteDelay = 0;
     this.volume = 1;
+    this.wordlistId = filter.audioWordlistId;
     this.youTubeAutoSubsMin = filter.cfg.youTubeAutoSubsMin;
 
     // Setup rules for current site
@@ -179,7 +181,7 @@ export default class WebAudio {
     subtitles.forEach(subtitle => {
       // innerText handles line feeds/spacing better, but is not available to #text nodes
       let textMethod = subtitle.nodeName === '#text' ? 'textContent' : 'innerText';
-      let result = this.filter.replaceTextResult(subtitle[textMethod]);
+      let result = this.replaceTextResult(subtitle[textMethod]);
       if (result.modified) {
         filtered = true;
         this.mute(rule.muteMethod); // Mute the audio if we haven't already
@@ -198,7 +200,7 @@ export default class WebAudio {
   }
 
   cleanYouTubeAutoSubs(node): void {
-    let result = this.filter.replaceTextResult(node.textContent);
+    let result = this.replaceTextResult(node.textContent);
     if (result.modified) {
       node.textContent = result.filtered;
       this.mute();
@@ -304,7 +306,7 @@ export default class WebAudio {
         cue.endTime += rule.videoCueSync;
       }
 
-      let result = this.filter.replaceTextResult(cue.text);
+      let result = this.replaceTextResult(cue.text);
       if (result.modified) {
         cue.filtered = true;
         cue.originalText = cue.text;
@@ -313,6 +315,10 @@ export default class WebAudio {
         cue.filtered = false;
       }
     }
+  }
+
+  replaceTextResult(string: string, stats: boolean = true) {
+    return this.filter.replaceTextResult(string, this.wordlistId, stats);
   }
 
   unmute(muteMethod: number = this.filter.cfg.muteMethod, video?: HTMLVideoElement): void {
@@ -367,7 +373,7 @@ export default class WebAudio {
 
             // Filter the captions/subtitles
             if (child[textMethod]) {
-              let result = instance.filter.replaceTextResult(child[textMethod]);
+              let result = instance.replaceTextResult(child[textMethod]);
               if (result.modified) {
                 instance.mute(rule.muteMethod);
                 filtered = true;
@@ -387,7 +393,7 @@ export default class WebAudio {
           if (!newCaptions && instance.lastProcessed.includes(captions[textMethod])) { return false; }
 
           if (captions[textMethod] && (instance.lastFilteredText && !captions[textMethod].contains(instance.lastFilteredText))) {
-            let result = instance.filter.replaceTextResult(captions[textMethod]);
+            let result = instance.replaceTextResult(captions[textMethod]);
             if (result.modified) {
               instance.mute(rule.muteMethod);
               filtered = true;

--- a/src/script/webAudio.ts
+++ b/src/script/webAudio.ts
@@ -31,14 +31,12 @@ export default class WebAudio {
     this.lastProcessed = [];
     this.muted = false;
     if (
-      filter.cfg.customAudioSites
-      && typeof filter.cfg.customAudioSites == 'object'
-      && Object.keys(filter.cfg.customAudioSites).length > 0
+      !filter.cfg.customAudioSites
+      || typeof filter.cfg.customAudioSites !== 'object'
     ) {
-      this.sites = Object.assign(WebAudio.sites, filter.cfg.customAudioSites);
-    } else {
-      this.sites = WebAudio.sites;
+      filter.cfg.customAudioSites = {};
     }
+    this.sites = Object.assign({}, WebAudio.sites, filter.cfg.customAudioSites);
     this.unmuteDelay = 0;
     this.volume = 1;
     this.wordlistId = filter.audioWordlistId;

--- a/src/script/webConfig.ts
+++ b/src/script/webConfig.ts
@@ -35,9 +35,12 @@ export default class WebConfig extends Config {
     youTubeAutoSubsMin: 0,
   }
 
+  static readonly QUOTA_BYTES_PER_ITEM = 8192; // https://developer.chrome.com/apps/storage chrome.storage.sync.QUOTA_BYTES_PER_ITEM
   static readonly _defaults = Object.assign(Config._defaults, WebConfig._classDefaults);
+  static readonly _maxBytes = 8000;
 
-  static async build(keys?: string[]) {
+  static async build(keys: string | string[] = []) {
+    if (typeof keys === 'string') { keys = [keys]; }
     let asyncResult = await WebConfig.getConfig(keys);
     let instance = new WebConfig(asyncResult);
     return instance;
@@ -53,8 +56,8 @@ export default class WebConfig extends Config {
     Object.assign(this, WebConfig._classDefaults, asyncParam); // Separate due to _defineProperty()
   }
 
-  // Compile words
-  static combineWords(items) {
+  // Combine all ._words* into .words
+  static combineWords(items): void {
     items.words = {};
     if (items._words0 !== undefined) {
       // Find all _words* to combine
@@ -71,66 +74,40 @@ export default class WebConfig extends Config {
     // console.log('combineWords', items); // DEBUG
   }
 
-  // Persist all configs from defaults and split _words*
-  dataToPersist() {
-    let self = this;
-    let data = {};
-
-    // Save all settings using keys from _defaults
-    Object.keys(WebConfig._defaults).forEach(function(key) {
-      if (self[key] !== undefined) {
-        data[key] = self[key];
-      }
-    });
-
-    if (self.words) {
-      // Split words back into _words* for storage
-      let splitWords = self.splitWords();
-      Object.keys(splitWords).forEach(function(key) {
-        data[key] = splitWords[key];
-      });
-
-      let wordKeys = Object.keys(self).filter(function(key) {
-        return Config._wordsPattern.test(key);
-      });
-
-      wordKeys.forEach(function(key){
-        data[key] = self[key];
-      });
-    }
-
-    // console.log('dataToPersist', data); // DEBUG - Config
-    return data;
-  }
-
   // Async call to get provided keys (or default keys) from chrome storage
-  // TODO: Keys: Doesn't support getting words
-  static getConfig(keys?: string[]) {
+  static getConfig(keys: string[]) {
     return new Promise(function(resolve, reject) {
-      // Generate a request to use with chrome.storage
-      let request = null;
-      if (keys !== undefined) {
+      let request = null; // Get all data from storage
+
+      if (keys.length > 0 && !keys.includes('words')) {
         request = {};
-        for (let k of keys) { request[k] = WebConfig._defaults[k]; }
+        keys.forEach(key => { request[key] = WebConfig._defaults[key]; });
       }
 
       chrome.storage.sync.get(request, function(items) {
         // Ensure defaults for undefined settings
-        Object.keys(WebConfig._defaults).forEach(function(defaultKey){
-          if (request == null || Object.keys(request).includes(defaultKey)) {
-            if (items[defaultKey] === undefined) {
-              items[defaultKey] = WebConfig._defaults[defaultKey];
-            }
+        Object.keys(WebConfig._defaults).forEach(function(defaultKey) {
+          if ((request == null || keys.includes(defaultKey)) && items[defaultKey] === undefined) {
+            items[defaultKey] = WebConfig._defaults[defaultKey];
           }
         });
 
         // Add words if requested, and provide _defaultWords if needed
-        if (keys === undefined || keys.includes('words')) {
+        if (keys.length === 0 || keys.includes('words')) {
           // Use default words if none were provided
           if (items._words0 === undefined || Object.keys(items._words0).length == 0) {
             items._words0 = Config._defaultWords;
           }
           WebConfig.combineWords(items);
+        }
+
+        // Remove keys we didn't request (needed for _words*)
+        if (request !== null && keys.length > 0) {
+          Object.keys(items).forEach(function(item) {
+            if (!keys.includes(item)) {
+              delete items[item];
+            }
+          });
         }
 
         resolve(items);
@@ -160,18 +137,24 @@ export default class WebConfig extends Config {
   }
 
   // Pass a key or array of keys to save, or save everything
-  // Note: To save words you'll need to leave props undefined
-  save(props?: string | string[]) {
+  save(props: string | string[] = []) {
+    let self = this;
+    if (typeof props === 'string') { props = [props]; }
     let data = {};
-    if (props === undefined) {
-      data = this.dataToPersist();
-    } else if (typeof props === 'string') {
-      data[props] = this[props];
-    } else if (Array.isArray(props)) {
-      for (let prop of props) {
-        data[prop] = this[prop];
-      }
+
+    // Save everything
+    if (props.length === 0) {
+      props = Object.keys(WebConfig._defaults);
+      props.push('words');
     }
+
+    props.forEach(function(prop) {
+      if (prop === 'words') {
+        Object.assign(data, self.splitWords());
+      } else {
+        data[prop] = self[prop];
+      }
+    });
 
     return new Promise(function(resolve, reject) {
       chrome.storage.sync.set(data, function() {
@@ -182,22 +165,35 @@ export default class WebConfig extends Config {
 
   splitWords() {
     let self = this;
+    const encoder = new TextEncoder();
+    const containerPrefix = '_words';
     let currentContainerNum = 0;
-    let currentWordNum = 0;
-    // let wordsLength = JSON.stringify(self.words).length;
-    // let wordContainers = Math.ceil(wordsLength/Config._maxBytes);
-    // let wordsNum = Object.keys(self.words).length;
+    let currentBytes = 2; // For double-quotes around entire stringified JSON
     let words = {};
-    words[`_words${currentContainerNum}`] = {};
+
+    let currentContainer = `${containerPrefix}${currentContainerNum}`;
+    words[currentContainer] = {};
+    currentBytes += encoder.encode(`{"${currentContainer}":{}}`).length;
+    // let debugString = '"{}"'; // DEBUG
+    // debugString += `"${currentContainer}":{}`; // DEBUG
 
     Object.keys(self.words).sort().forEach(function(word) {
-      if (currentWordNum == Config._maxWords) {
+      let newBytes = encoder.encode(`",${word}":`).length; // This leads to an extra ',' for the last entry
+      newBytes += encoder.encode(JSON.stringify(self.words[word])).length;
+
+      // Next word would be too big, setup next container
+      if ((currentBytes + newBytes) >= WebConfig._maxBytes) {
         currentContainerNum++;
-        currentWordNum = 0;
-        words[`_words${currentContainerNum}`] = {};
+        currentContainer = `${containerPrefix}${currentContainerNum}`;
+        words[currentContainer] = {};
+        currentBytes = encoder.encode(`"${currentContainer}":{}`).length;
       }
-      words[`_words${currentContainerNum}`][word] = self.words[word];
-      currentWordNum++;
+
+      // Adding a word
+      // debugString += `"${word}":,`; // DEBUG
+      // debugString += JSON.stringify(self.words[word]); // DEBUG
+      currentBytes += newBytes;
+      words[currentContainer][word] = self.words[word];
     });
 
     return words;

--- a/src/script/webConfig.ts
+++ b/src/script/webConfig.ts
@@ -2,11 +2,9 @@ import Config from './lib/config';
 
 export default class WebConfig extends Config {
   _splitContainerKeys: { [key: string]: string[] };
-  advancedDomains: string[];
   audioWordlistId: number;
   customAudioSites: { [site: string]: AudioRules[] };
-  disabledDomains: string[];
-  enabledDomains: string[];
+  domains: { [site: string]: DomainCfg };
   enabledDomainsOnly: boolean;
   muteAudio: boolean;
   muteAudioOnly: boolean;
@@ -19,11 +17,9 @@ export default class WebConfig extends Config {
   youTubeAutoSubsMin: number;
 
   static readonly _classDefaults = {
-    advancedDomains: [],
+    domains: {},
     audioWordlistId: 0,
     customAudioSites: null,
-    disabledDomains: [],
-    enabledDomains: [],
     enabledDomainsOnly: false,
     muteAudio: false,
     muteAudioOnly: false,
@@ -38,7 +34,7 @@ export default class WebConfig extends Config {
 
   static readonly QUOTA_BYTES_PER_ITEM = 8192; // https://developer.chrome.com/apps/storage chrome.storage.sync.QUOTA_BYTES_PER_ITEM
   static readonly _defaults = Object.assign(Config._defaults, WebConfig._classDefaults);
-  static readonly _splittingKeys = ['words'];
+  static readonly _splittingKeys = ['domains', 'words'];
   static readonly _maxBytes = 8000;
 
   static async build(keys: string | string[] = []) {

--- a/src/script/webConfig.ts
+++ b/src/script/webConfig.ts
@@ -17,7 +17,7 @@ export default class WebConfig extends Config {
   youTubeAutoSubsMax: number;
   youTubeAutoSubsMin: number;
 
-  static readonly _webConfigDefaults = {
+  static readonly _classDefaults = {
     advancedDomains: [],
     audioWordlistId: 0,
     customAudioSites: null,
@@ -35,7 +35,7 @@ export default class WebConfig extends Config {
     youTubeAutoSubsMin: 0,
   }
 
-  static readonly _defaults = Object.assign(Config._defaults, WebConfig._webConfigDefaults);
+  static readonly _defaults = Object.assign(Config._defaults, WebConfig._classDefaults);
 
   static async build(keys?: string[]) {
     let asyncResult = await WebConfig.getConfig(keys);
@@ -50,7 +50,7 @@ export default class WebConfig extends Config {
     }
 
     super(); // Get the Config defaults
-    Object.assign(this, WebConfig._webConfigDefaults, asyncParam); // Separate due to _defineProperty()
+    Object.assign(this, WebConfig._classDefaults, asyncParam); // Separate due to _defineProperty()
   }
 
   // Compile words

--- a/src/script/webConfig.ts
+++ b/src/script/webConfig.ts
@@ -1,6 +1,13 @@
 import Config from './lib/config';
 
 export default class WebConfig extends Config {
+  audioWordlistId: number;
+
+  static readonly _webConfigDefaults = {
+    audioWordlistId: 0
+  }
+  static readonly _defaults = Object.assign(Config._defaults, WebConfig._webConfigDefaults);
+
   static async build(keys?: string[]) {
     let asyncResult = await WebConfig.getConfig(keys);
     let instance = new WebConfig(asyncResult);
@@ -13,7 +20,8 @@ export default class WebConfig extends Config {
       throw new Error('Cannot be called directly. call build()');
     }
 
-    super(asyncParam);
+    super(); // Get the Config defaults
+    Object.assign(this, WebConfig._webConfigDefaults, asyncParam); // Separate due to _defineProperty()
   }
 
   // Compile words
@@ -40,7 +48,7 @@ export default class WebConfig extends Config {
     let data = {};
 
     // Save all settings using keys from _defaults
-    Object.keys(Config._defaults).forEach(function(key) {
+    Object.keys(WebConfig._defaults).forEach(function(key) {
       if (self[key] !== undefined) {
         data[key] = self[key];
       }
@@ -74,15 +82,15 @@ export default class WebConfig extends Config {
       let request = null;
       if (keys !== undefined) {
         request = {};
-        for (let k of keys) { request[k] = Config._defaults[k]; }
+        for (let k of keys) { request[k] = WebConfig._defaults[k]; }
       }
 
       chrome.storage.sync.get(request, function(items) {
         // Ensure defaults for undefined settings
-        Object.keys(Config._defaults).forEach(function(defaultKey){
+        Object.keys(WebConfig._defaults).forEach(function(defaultKey){
           if (request == null || Object.keys(request).includes(defaultKey)) {
             if (items[defaultKey] === undefined) {
-              items[defaultKey] = Config._defaults[defaultKey];
+              items[defaultKey] = WebConfig._defaults[defaultKey];
             }
           }
         });

--- a/src/script/webConfig.ts
+++ b/src/script/webConfig.ts
@@ -1,11 +1,40 @@
 import Config from './lib/config';
 
 export default class WebConfig extends Config {
+  advancedDomains: string[];
   audioWordlistId: number;
+  customAudioSites: { [site: string]: AudioRules[] };
+  disabledDomains: string[];
+  enabledDomains: string[];
+  enabledDomainsOnly: boolean;
+  muteAudio: boolean;
+  muteAudioOnly: boolean;
+  muteCueRequireShowing: boolean;
+  muteMethod: number;
+  password: string;
+  showSubtitles: number;
+  showUpdateNotification: boolean;
+  youTubeAutoSubsMax: number;
+  youTubeAutoSubsMin: number;
 
   static readonly _webConfigDefaults = {
-    audioWordlistId: 0
+    advancedDomains: [],
+    audioWordlistId: 0,
+    customAudioSites: null,
+    disabledDomains: [],
+    enabledDomains: [],
+    enabledDomainsOnly: false,
+    muteAudio: false,
+    muteAudioOnly: false,
+    muteCueRequireShowing: true,
+    muteMethod: 0, // 0: Mute Tab, 1: Video Volume
+    password: null,
+    showSubtitles: 0,
+    showUpdateNotification: true,
+    youTubeAutoSubsMax: 0,
+    youTubeAutoSubsMin: 0,
   }
+
   static readonly _defaults = Object.assign(Config._defaults, WebConfig._webConfigDefaults);
 
   static async build(keys?: string[]) {

--- a/src/script/webConfig.ts
+++ b/src/script/webConfig.ts
@@ -33,7 +33,7 @@ export default class WebConfig extends Config {
   }
 
   static readonly QUOTA_BYTES_PER_ITEM = 8192; // https://developer.chrome.com/apps/storage chrome.storage.sync.QUOTA_BYTES_PER_ITEM
-  static readonly _defaults = Object.assign(Config._defaults, WebConfig._classDefaults);
+  static readonly _defaults = Object.assign({}, Config._defaults, WebConfig._classDefaults);
   static readonly _splittingKeys = ['domains', 'words'];
   static readonly _maxBytes = 8000;
 

--- a/src/script/webConfig.ts
+++ b/src/script/webConfig.ts
@@ -1,13 +1,13 @@
 import Config from './lib/config';
 
 export default class WebConfig extends Config {
+  _wordContainerKeys: string[];
   advancedDomains: string[];
   audioWordlistId: number;
   customAudioSites: { [site: string]: AudioRules[] };
   disabledDomains: string[];
   enabledDomains: string[];
   enabledDomainsOnly: boolean;
-  wordContainerKeys: string[]; // Internal use - not persisted
   muteAudio: boolean;
   muteAudioOnly: boolean;
   muteCueRequireShowing: boolean;
@@ -56,7 +56,7 @@ export default class WebConfig extends Config {
     }
 
     super(); // Get the Config defaults
-    this.wordContainerKeys = [];
+    this._wordContainerKeys = [];
     Object.assign(this, WebConfig._classDefaults, asyncParam); // Separate due to _defineProperty()
   }
 
@@ -99,7 +99,7 @@ export default class WebConfig extends Config {
           if (items._words0 === undefined || Object.keys(items._words0).length == 0) {
             items._words0 = Config._defaultWords;
           }
-          items.wordContainerKeys = WebConfig.combineWords(items);
+          items._wordContainerKeys = WebConfig.combineWords(items);
         }
 
         // Remove keys we didn't request (needed for _words*)
@@ -173,10 +173,10 @@ export default class WebConfig extends Config {
     // If we have more containers in storage than are needed, remove them
     if (props.length === 0 || props.includes('words')) {
       let newWordKeys = WebConfig.getWordContainerKeys(data);
-      let containersToRemove = self.wordContainerKeys.filter(oldKey => !newWordKeys.includes(oldKey));
+      let containersToRemove = self._wordContainerKeys.filter(oldKey => !newWordKeys.includes(oldKey));
       if (containersToRemove.length !== 0) {
         self.remove(containersToRemove);
-        self.wordContainerKeys = newWordKeys;
+        self._wordContainerKeys = newWordKeys;
       }
     }
 

--- a/src/script/webConfig.ts
+++ b/src/script/webConfig.ts
@@ -109,6 +109,14 @@ export default class WebConfig extends Config {
     });
   }
 
+  ordered() {
+    let self = this;
+    return Object.keys(self).sort().reduce((obj, key) => {
+      obj[key] = self[key];
+      return obj;
+    }, {});
+  }
+
   removeProp(prop: string) {
     chrome.storage.sync.remove(prop);
     delete this[prop];

--- a/src/script/webFilter.ts
+++ b/src/script/webFilter.ts
@@ -16,7 +16,6 @@ export default class WebFilter extends Filter {
   iframe: Location;
   mutePage: boolean;
   summary: Summary;
-  youTubeMutePage: boolean;
 
   constructor() {
     super();

--- a/src/script/webFilter.ts
+++ b/src/script/webFilter.ts
@@ -271,14 +271,6 @@ export default class WebFilter extends Filter {
     filter.updateCounterBadge();
   }
 
-  replaceTextResult(string: string, stats: boolean = true) {
-    let result = {} as any;
-    result.original = string;
-    result.filtered = filter.replaceText(string, stats);
-    result.modified = (result.filtered != string);
-    return result;
-  }
-
   sendInitState(message: Message) {
     // Reset muted state on page load if we muted the tab audio
     if (this.cfg.muteAudio && this.cfg.muteMethod == 0) { message.clearMute = true; }

--- a/src/script/webFilter.ts
+++ b/src/script/webFilter.ts
@@ -33,14 +33,14 @@ export default class WebFilter extends Filter {
   advancedReplaceText(node, wordlistId: number, stats = true) {
     filter.wordlists[wordlistId].regExps.forEach((regExp) => {
       // @ts-ignore - External library function
-      findAndReplaceDOMText(node, {preset: 'prose', find: regExp, replace: function(portion, match) {
+      findAndReplaceDOMText(node, { preset: 'prose', find: regExp, replace: function(portion, match) {
         // console.log('[APF] Advanced node match:', node.textContent); // Debug: Filter - Advanced match
         if (portion.index === 0) { // Replace the whole match on the first portion and skip the rest
           return filter.replaceText(match[0], wordlistId, stats);
         } else {
           return '';
         }
-      }});
+      } });
     });
   }
 

--- a/src/static/optionPage.css
+++ b/src/static/optionPage.css
@@ -25,5 +25,17 @@ h4.sectionHeader
 /* Bookmarklet Link */
 a#bookmarkletLink:active, a#bookmarkletLink:hover, a#bookmarkletLink:link, a#bookmarkletLink:visited
 {color: #fff}
+/* Modals */
+#confirmModal,#passwordModal,#statusModal
+{z-index:900}
+#bulkWordEditorModal,#supportedAudioSitesModal
+{z-index:500}
+/* Bulk Word Editor */
+#bulkWordEditorModal table
+{border:none;} /* Fix small gap on sticky header from .w3-table-all */
+#bulkWordEditorModal table th
+{background-color:var(--silver);position:sticky;top:0;z-index:10;vertical-align:middle;}
+#bulkWordEditorModal table th input,span
+{vertical-align:middle;}
 #supportedAudioSitesModal textarea
 {width:420px;height:400px;font-size:11px;}

--- a/src/static/optionPage.css
+++ b/src/static/optionPage.css
@@ -1,7 +1,11 @@
+html {
+  --blue: #2980b9; /* belize-hole */
+  --silver: #bdc3c7;
+}
 a:hover
-{color:#2980b9}
+{color:var(--blue)}
 h4.sectionHeader
-{color:#3498db}
+{color:var(--blue)}
 #header img
 {margin-bottom:8px}
 /* #helpPage
@@ -9,7 +13,7 @@ h4.sectionHeader
 #main
 {padding-bottom:16px}
 #menu > a:hover
-{color:#fff!important;background-color:#2980b9!important}
+{color:#fff!important;background-color:var(--blue)!important}
 .updateYouTubeAutoLimits
 {width:70px;text-align:right;}
 .disabled

--- a/src/static/optionPage.css
+++ b/src/static/optionPage.css
@@ -25,3 +25,5 @@ h4.sectionHeader
 /* Bookmarklet Link */
 a#bookmarkletLink:active, a#bookmarkletLink:hover, a#bookmarkletLink:link, a#bookmarkletLink:visited
 {color: #fff}
+#supportedAudioSitesModal textarea
+{width:420px;height:400px;font-size:11px;}

--- a/src/static/optionPage.html
+++ b/src/static/optionPage.html
@@ -160,7 +160,7 @@
 </div>
 
 <div id="wordsPage" class="w3-container w3-hide">
-  <div class="w3-container w3-half">
+  <div class="w3-half">
     <h4 class="sectionHeader">Words & Phrases</h4>
     <select id="wordList" class="w3-select w3-border small"></select>
     <label><input id="filterWordList" type="checkbox" class="w3-check">  Filter</label>

--- a/src/static/optionPage.html
+++ b/src/static/optionPage.html
@@ -112,13 +112,6 @@
     </div>
   </div>
 
-  <div id="globalMatchMethod" class="w3-hide">
-    <h4 class="sectionHeader">Global Matching Method</h4>
-    <label>
-      <select id="globalMatchMethodSelect" class="w3-select w3-border small"></select>
-    </label>
-  </div>
-
   <div id="generalOptions">
     <h4 class="sectionHeader">General Settings</h4>
     <label>

--- a/src/static/optionPage.html
+++ b/src/static/optionPage.html
@@ -217,6 +217,7 @@
     <button id="wordSave" class="w3-btn w3-round-large w3-flat-peter-river">SAVE</button>
     <button id="wordRemove" class="w3-btn w3-round-large w3-flat-pomegranate">REMOVE</button>
     <button id="wordRemoveAll" class="w3-btn w3-round-large w3-flat-pomegranate">REMOVE ALL</button>
+    <button id="bulkWordEditorButton" class="w3-btn w3-right w3-round-large w3-flat-peter-river">BULK EDITOR</button>
   </div>
 </div>
 
@@ -592,6 +593,24 @@
   </div>
 </div>
 </div> <!-- /div#main -->
+
+<div id="bulkWordEditorModal" class="w3-modal">
+  <div class="w3-modal-content w3-card-4 w3-animate-zoom" style="width: 98%;">
+    <header class="w3-container w3-flat-peter-river"><h5 class="modalTitle"></h5></header>
+    <div class="w3-container w3-margin w3-padding">
+      <div class="tableContainer  w3-card" style="overflow: auto; height: 600px;"></div>
+      <div class="w3-margin-top">
+        <textarea id="bulkAddWordsText" class="batchAddWord w3-left w3-margin-right" style="width:300px;height:50px;font-size:11px;" spellcheck="false" placeholder="Bulk add words (one word/phrase per line)"></textarea>
+        <button class="modalBulkAddWords w3-btn w3-round-large w3-flat-peter-river">BULK ADD WORDS</button>
+        <div class="w3-right">
+          <button class="modalAddWord w3-btn w3-round-large w3-flat-peter-river">ADD WORD</button>
+          <button class="modalCancel w3-btn w3-round-large w3-flat-peter-river">CANCEL</button>
+          <button class="modalSave w3-btn w3-round-large w3-flat-pomegranate">SAVE</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 
 <div id="confirmModal" class="w3-modal">
   <div class="w3-modal-content w3-card-4 w3-animate-zoom">

--- a/src/static/optionPage.html
+++ b/src/static/optionPage.html
@@ -16,6 +16,7 @@
 <div id="menu" class="w3-bar w3-flat-peter-river w3-card">
   <a href="#" class="w3-bar-item w3-button w3-flat-belize-hole">Settings</a>
   <a href="#" class="w3-bar-item w3-button">Words</a>
+  <a href="#" class="w3-bar-item w3-button">Lists</a>
   <a href="#" class="w3-bar-item w3-button">Domains</a>
   <a href="#" class="w3-bar-item w3-button">Audio</a>
   <a href="#" class="w3-bar-item w3-button">Bookmarklet</a>
@@ -197,29 +198,37 @@
         <input id="wordMatchRegular-Expression" type="radio" class="w3-radio" name="wordMatchMethod" value="Regular-Expression">
         Regex
       </label>
-
-      <h4 class="sectionHeader">Other</h4>
-      <label>
-        <input id="wordMatchRepeated" type="checkbox" class="w3-check" name="matchRepeat"/>
-        Match repeated characters<span class="notes">(dog: dddoooggg)</span>
-      </label>
-
-      <br>
-      <label>
-        <input id="wordMatchSeparators" type="checkbox" class="w3-check" name="matchSeparators"/>
-        Match separators<span class="notes">([-_ ] dog matches: D-o _g)</span>
-      </label>
-    </div>
-    <br>
-
-    <div class="w3-left">
-      <button id="wordSave" class="w3-btn w3-round-large w3-flat-peter-river">SAVE</button>
-      <button id="wordRemove" class="w3-btn w3-round-large w3-flat-pomegranate">REMOVE</button>
-      <button id="wordRemoveAll" class="w3-btn w3-round-large w3-flat-pomegranate">REMOVE ALL</button>
     </div>
   </div>
 
-  <div class="w3-container w3-half w3-right">
+  <div class="w3-half w3-right">
+    <div id="wordWordlistDiv" class="w3-hide">
+      <h4 class="sectionHeader">Include in Wordlists</h4>
+      <div id="wordlistSelections"></div>
+    </div>
+
+    <h4 class="sectionHeader">Other</h4>
+    <label>
+      <input id="wordMatchRepeated" type="checkbox" class="w3-check" name="matchRepeat"/>
+      Match repeated characters<span class="notes">(dog: dddoooggg)</span>
+    </label>
+
+    <br>
+    <label>
+      <input id="wordMatchSeparators" type="checkbox" class="w3-check" name="matchSeparators"/>
+      Match separators<span class="notes">([-_ ] dog matches: D-o _g)</span>
+    </label>
+  </div>
+
+  <div class="w3-container w3-center" style="width: 100%;">
+    <button id="wordSave" class="w3-btn w3-round-large w3-flat-peter-river">SAVE</button>
+    <button id="wordRemove" class="w3-btn w3-round-large w3-flat-pomegranate">REMOVE</button>
+    <button id="wordRemoveAll" class="w3-btn w3-round-large w3-flat-pomegranate">REMOVE ALL</button>
+  </div>
+</div>
+
+<div id="listsPage" class="w3-container w3-hide">
+  <div class="w3-half w3">
     <h4 class="sectionHeader">Whitelist</h4>
     <select id="whitelist" class="w3-select w3-border small"></select><span class="notes">(* Case-sensitive)</span>
 
@@ -242,6 +251,29 @@
     <div class="w3-left" style="padding-top: 20px;">
       <button id="whitelistSave" class="w3-btn w3-round-large w3-flat-peter-river">SAVE</button>
       <button id="whitelistRemove" class="w3-btn w3-round-large w3-flat-pomegranate">REMOVE</button>
+    </div>
+  </div>
+
+  <div class="w3-half w3-right">
+    <label style="display: block;">
+      <h4 class="sectionHeader" style="display: inline-block; height: 30px;">Word Lists</h4>
+      <input id="wordlistsEnabled" type="checkbox" class="w3-check">
+    </label>
+
+    <div id="wordlistContainer" class="w3-hide">
+      <select id="wordlistSelect" class="w3-select w3-border small"></select>
+
+      <h4 class="sectionHeader">Name</h4>
+      <input id="wordlistText" class="w3-input w3-border small" type="text" pattern="^\S.*" required style="display: inline; margin-right: 8px;">
+      <button id="wordlistRename" class="w3-btn w3-round-large w3-flat-peter-river">RENAME</button>
+
+      <h4 class="sectionHeader">Active Word List (Text)</h4>
+      <select id="textWordlistSelect" class="w3-select w3-border small"></select><span class="notes"></span>
+
+      <div id="audioWordlistDiv" class="w3-hide">
+        <h4 class="sectionHeader">Active Word List (Audio)</h4>
+        <select id="audioWordlistSelect" class="w3-select w3-border small"></select><span class="notes"></span>
+      </div>
     </div>
   </div>
 </div>

--- a/src/static/optionPage.html
+++ b/src/static/optionPage.html
@@ -274,44 +274,64 @@
 
 <div id="domainsPage" class="w3-container w3-hide">
   <div id="disabledDomainContainer" class="w3-half">
-      <h4 class="sectionHeader">Domain Mode</h4>
+    <h4 class="sectionHeader">Domain Mode</h4>
 
-      <div id="domainMode">
-        <label>
-          <input id="domainModeWhitelist" type="radio" class="w3-radio" name="domainMode" value="disabledDomains">
-          Whitelist
-          <span class="notes">Filter all but these domains</span>
-        </label>
+    <div id="domainMode">
+      <label>
+        <input id="domainModeWhitelist" type="radio" class="w3-radio" name="domainMode" value="whitelist">
+        Whitelist
+        <span class="notes">Filter all but these domains</span>
+      </label>
 
-        <br>
-        <label>
-          <input id="domainModeBlacklist" type="radio" class="w3-radio" name="domainMode" value="enabledDomains">
-          Blacklist
-          <span class="notes">Only filter these domains</span>
-        </label>
-      </div>
+      <br>
+      <label>
+        <input id="domainModeBlacklist" type="radio" class="w3-radio" name="domainMode" value="blacklist">
+        Blacklist
+        <span class="notes">Only filter these domains</span>
+      </label>
+    </div>
+  </div>
 
-      <h4 class="sectionHeader">Domains</h4>
-      <select id="domainSelect" class="w3-select w3-border small" style="display:block"></select>
-      <h4 class="sectionHeader">Domain</h4>
-      <input id="domainText" class="w3-input w3-border small" type="text" pattern="^[a-zA-Z0-9\.-]+\.[a-zA-Z0-9\.-]+$"/>
-      <span class="notes">Example: "google.com" or "mail.google.com"</span>
-      <div style="padding-top: 16px;">
-        <button id="domainSave" class="w3-btn w3-round-large w3-flat-peter-river">SAVE</button>
-        <button id="domainRemove" class="w3-btn w3-round-large w3-flat-pomegranate">REMOVE</button>
+  <div id="domainRightContainer" class="w3-half w3-right">
+    <h4 class="sectionHeader">Domains</h4>
+    <select id="domainSelect" class="w3-select w3-border small" style="display:block"></select>
+    <h4 class="sectionHeader">Domain</h4>
+    <input id="domainText" class="w3-input w3-border small" type="text" pattern="^[a-zA-Z0-9\.-]+\.[a-zA-Z0-9\.-]+$"/>
+    <span class="notes">Example: "google.com" or "mail.google.com"</span>
+
+    <br>
+    <br>
+    <label id="domainDisabledLabel" class="w3-hide">
+      <input id="domainDisabledCheck" type="checkbox" class="w3-check">
+      Disabled
+      <span class="notes">Don't filter pages on this domain</span>
+    </label>
+
+    <label id="domainEnabledLabel" class="w3-hide">
+      <input id="domainEnabledCheck" type="checkbox" class="w3-check">
+      Enabled
+      <span class="notes">Filter pages on this domain</span>
+    </label>
+
+    <label>
+      <input id="domainAdvancedCheck" type="checkbox" class="w3-check">
+      Advanced
+      <span class="notes">Match across HTML Elements (Only use when necessary)</span>
+    </label>
+
+    <div id="domainWordlistContainer" class="w3-hide">
+      <h4 class="sectionHeader">Text Wordlist</h4>
+      <select id="domainWordlistSelect" class="w3-select w3-border small"></select><span class="notes"></span>
+
+      <div id="domainAudioWordlistContainer" class="w3-hide">
+        <h4 class="sectionHeader">Audio Wordlist</h4>
+        <select id="domainAudioWordlistSelect" class="w3-select w3-border small"></select><span class="notes"></span>
       </div>
     </div>
 
-  <div id="advDomainContainer" class="w3-half w3-right">
-    <h4 class="sectionHeader">Advanced Domains</h4>
-    <select id="advDomainSelect" class="w3-select w3-border small" style="display:block"></select>
-    <span class="notes">Only use when the filter isn't working.</span>
-    <h4 class="sectionHeader">Domain</h4>
-    <input id="advDomainText" class="w3-input w3-border small" type="text" pattern="^[a-zA-Z0-9\.-]+\.[a-zA-Z0-9\.-]+$"/>
-    <span class="notes">Example: "google.com" or "mail.google.com"</span>
     <div style="padding-top: 16px;">
-      <button id="advDomainSave" class="w3-btn w3-round-large w3-flat-peter-river">SAVE</button>
-      <button id="advDomainRemove" class="w3-btn w3-round-large w3-flat-pomegranate">REMOVE</button>
+      <button id="domainSave" class="w3-btn w3-round-large w3-flat-peter-river">SAVE</button>
+      <button id="domainRemove" class="w3-btn w3-round-large w3-flat-pomegranate">REMOVE</button>
     </div>
   </div>
 </div>

--- a/src/static/popup.css
+++ b/src/static/popup.css
@@ -53,15 +53,12 @@ input:checked + .slider:before {
   color: #DA291C;
 }
 
-#filterMethodSelect {
-  width: 150px;
-}
-
 #footer {
   width: 100%;
   padding: 15px 0;
   background: #ccc;
   text-align: center;
+  margin-top: 8px;
 }
 
 #gettingStarted {
@@ -90,6 +87,14 @@ input:checked + .slider:before {
   background-color: #ddd;
 }
 
+.checkbox {
+  margin-left: 8px;
+}
+
+.checkboxLabel {
+  line-height: 34px;
+}
+
 .container {
   margin-top:8px;
   margin-bottom:8px;
@@ -108,6 +113,24 @@ input:checked + .slider:before {
 .options {
   width: 200px;
   margin-left: 25px;
+}
+
+.selectLabel {
+  line-height: 39px;
+  padding-left: 15px;
+}
+
+.smallHeader {
+  color: var(--blue);
+  padding-top: 4px;
+  padding-right: 8px;
+}
+
+.smallSelect {
+  width: 150px;
+  float: right;
+  display:inline;
+  margin-right:25px;
 }
 
 .unselectable {

--- a/src/static/popup.html
+++ b/src/static/popup.html
@@ -16,15 +16,25 @@
   <div class="divider"></div>
 
   <div id="advancedModeContainer" class="w3-center container">
-    <label>Advanced Mode <input id="advancedMode" class="w3-check unselectable" type="checkbox"></label>
+    <label class="checkboxLabel">Advanced Mode<input id="advancedMode" class="w3-check unselectable checkbox" type="checkbox"></label>
   </div>
 
   <div class="divider"></div>
 
   <div id="filterMethodContainer" class="w3-center container">
     <div class="filter">
-      <label>Filter <select id="filterMethodSelect" class="w3-select w3-border" style="display:inline;"></select></label>
+      <label class="selectLabel">Filter<select id="filterMethodSelect" class="w3-select w3-border smallSelect"></select></label>
     </div>
+  </div>
+
+  <!-- <div class="divider"></div>
+
+  <div class="w3-center smallHeader">Active Wordlist</div> -->
+  <div id="wordListContainer" class="w3-center container w3-hide">
+    <label class="selectLabel">Text</label><select id="wordlistSelect" class="w3-select w3-border smallSelect"></select>
+  </div>
+  <div id="audioWordlistContainer" class="w3-center container w3-hide">
+    <label class="selectLabel">Audio</label><select id="audioWordlistSelect" class="w3-select w3-border smallSelect"></select>
   </div>
 
   <div class="divider"></div>
@@ -37,7 +47,7 @@
     <button id="options" class="w3-button w3-border w3-border-blue">Options</button>
   </div>
 
-  <div id="footer" style="margin-top:8px">
+  <div id="footer">
     <a id="gettingStarted" href="https://github.com/richardfrost/AdvancedProfanityFilter/wiki" target="_blank">Help</a>
     - <a href="https://github.com/richardfrost/AdvancedProfanityFilter/releases" target="_blank">Changelog</a>
     - <a href="https://github.com/richardfrost/AdvancedProfanityFilter/issues" target="_blank">Support</a>

--- a/test/dataMigration.spec.js
+++ b/test/dataMigration.spec.js
@@ -1,0 +1,25 @@
+const expect = require('chai').expect;
+import DataMigration from './built/dataMigration';
+
+describe('DataMigration', function() {
+  describe('removeOldDomainArrays()', function() {
+    it('should migrate all old domain arrays', function() {
+      let cfg = {
+        advancedDomains: ['example.com', 'www.example.com'],
+        disabledDomains: ['test.com', 'test.org'],
+        domains: {},
+        enabledDomains: ['enabled.com', 'example.com'],
+      };
+      let dataMigration = new DataMigration(cfg);
+      dataMigration.removeOldDomainArrays();
+      expect(cfg.advancedDomains).to.be.undefined;
+      expect(cfg.disabledDomains).to.be.undefined;
+      expect(cfg.enabledDomains).to.be.undefined;
+      expect(Object.keys(cfg.domains).length).to.equal(5);
+      expect(cfg.domains['example.com'].adv).to.be.true;
+      expect(cfg.domains['example.com'].enabled).to.be.true;
+      expect(cfg.domains['test.org'].disabled).to.be.true;
+      expect(cfg.domains['test.org'].adv).to.be.undefined;
+    });
+  });
+});

--- a/test/dataMigration.spec.js
+++ b/test/dataMigration.spec.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 import DataMigration from './built/dataMigration';
-import WebConfig from './built/WebConfig';
+import WebConfig from './built/webConfig';
 
 describe('DataMigration', function() {
   describe('addWordlistsToWords()', function() {

--- a/test/dataMigration.spec.js
+++ b/test/dataMigration.spec.js
@@ -1,7 +1,48 @@
 const expect = require('chai').expect;
 import DataMigration from './built/dataMigration';
+import WebConfig from './built/WebConfig';
 
 describe('DataMigration', function() {
+  describe('addWordlistsToWords()', function() {
+    it('should add wordlist to all words', function() {
+      let cfg = {
+        words: {
+          'test': { matchMethod: 0, repeat: true, separators: false, sub: 'tset' },
+          'another': { matchMethod: 0, repeat: true, separators: false, sub: 'tset' },
+          'testWithList': { lists: [1,3,5], matchMethod: 0, repeat: true, separators: false, sub: 'tset' },
+        }
+      };
+      let dataMigration = new DataMigration(cfg);
+      dataMigration.addWordlistsToWords();
+      expect(cfg.words['test'].lists).to.eql([]);
+      expect(cfg.words['another'].lists).to.eql([]);
+      expect(cfg.words['testWithList'].lists).to.eql([1,3,5]);
+    });
+  });
+
+  describe('removeGlobalMatchMethod()', function() {
+    it('should remove global match method and adjust RegExp method', function() {
+      let data = {
+        words: {
+          'test': { matchMethod: 0, repeat: true, separators: false, sub: 'tset' },
+          'another': { matchMethod: 1, repeat: true, separators: false, sub: 'tset' },
+          'testWithList': { lists: [1,3,5], matchMethod: 0, repeat: true, separators: false, sub: 'tset' },
+          '^myRegexp$': { lists: [1,3,5], matchMethod: 4, repeat: true, separators: false, sub: 'tset' },
+        },
+        globalMatchMethod: 3,
+      };
+      let cfg = new WebConfig(data);
+      cfg.remove = (prop) => { delete cfg[prop]; return true; }; // TODO: Find a good way to mock chrome.*
+      let dataMigration = new DataMigration(cfg);
+      dataMigration.removeGlobalMatchMethod();
+      expect(cfg.words['test'].matchMethod).to.eql(0);
+      expect(cfg.words['another'].matchMethod).to.eql(1);
+      expect(cfg.words['testWithList'].matchMethod).to.eql(0);
+      expect(cfg.words['^myRegexp$'].matchMethod).to.eql(3);
+      expect(cfg.globalMatchMethod).to.not.exist;
+    });
+  });
+
   describe('removeOldDomainArrays()', function() {
     it('should migrate all old domain arrays', function() {
       let cfg = {

--- a/test/domain.spec.js
+++ b/test/domain.spec.js
@@ -1,42 +1,125 @@
 const expect = require('chai').expect;
 import Domain from './built/domain';
+import WebConfig from './built/webConfig';
 
-const domains = ['example.com', 'sub.example.com', 'alt.example.com', 'another.sample.com'];
+const domains = {
+  'another.com': { adv: true },
+  'a.example.com': { enabled: true },
+  'www.example.com': { disabled: true },
+  'abc.zoo.edu': { disabled: true }
+};
 
 describe('Domain', function() {
-  describe('domainMatch()', function() {
-    it('should return true when a matching domain is found', function() {
-      expect(Domain.domainMatch('example.com', domains)).to.equal(true);
+  describe('.byKey()', function() {
+    it('should give a new domain with defaults if no matching record', function() {
+      let cfg = new WebConfig({ domains: domains });
+      let key = 'www.example.org';
+      let domain = Domain.byKey(key, cfg.domains);
+      expect(domain.advanced).to.be.undefined;
+      expect(domain.disabled).to.be.undefined;
+      expect(domain.enabled).to.be.undefined;
+      expect(domain.wordlist).to.be.undefined;
+      expect(domain.audioList).to.be.undefined;
+      expect(domain.cfgKey).to.eq(key);
     });
 
-    it('should return true when a parent domain is found', function() {
-      expect(Domain.domainMatch('other.example.com', domains)).to.equal(true);
+    it('should give a domain with exact domain match', function() {
+      let cfg = new WebConfig({ domains: domains });
+      let key = 'www.example.com';
+      let domain = Domain.byKey(key, cfg.domains);
+      expect(domain.advanced).to.be.undefined;
+      expect(domain.disabled).to.be.true;
+      expect(domain.cfg.disabled).to.be.true;
+      expect(domain.enabled).to.be.undefined;
+      expect(domain.wordlist).to.be.undefined;
+      expect(domain.audioList).to.be.undefined;
+      expect(domain.cfgKey).to.eq(key);
     });
 
-    it('should return false when a more specific (subdomain) domain is listed', function() {
-      expect(Domain.domainMatch('sample.com', domains)).to.equal(false);
-    });
-
-    it('should return false on an empty list of domains', function() {
-      expect(Domain.domainMatch('example.com', [])).to.equal(false);
+    it('should give return for exact match', function() {
+      let cfg = new WebConfig({ domains: domains });
+      let key = 'sub.another.com';
+      let domain = Domain.byKey(key, cfg.domains);
+      expect(domain.advanced).to.be.undefined;
+      expect(domain.disabled).to.be.undefined;
+      expect(domain.enabled).to.be.undefined;
+      expect(domain.wordlist).to.be.undefined;
+      expect(domain.audioList).to.be.undefined;
+      expect(domain.cfgKey).to.eq(key);
     });
   });
 
-  describe('removeFromList()', function() {
-    it('should remove parent domain and not subdomains when give a parent domain', function() {
-      expect(Domain.removeFromList('example.com', domains)).to.eql(['sub.example.com', 'alt.example.com', 'another.sample.com']);
+  describe('.byHostname()', function() {
+    it('should give a new domain with defaults if no matching record', function() {
+      let cfg = new WebConfig({ domains: domains });
+      let hostname = 'www.example.org';
+      let domain = Domain.byHostname(hostname, cfg.domains);
+      expect(domain.advanced).to.be.undefined;
+      expect(domain.disabled).to.be.undefined;
+      expect(domain.enabled).to.be.undefined;
+      expect(domain.wordlist).to.be.undefined;
+      expect(domain.audioList).to.be.undefined;
+      expect(domain.cfgKey).to.eq(hostname);
     });
 
-    it('should remove the specific subdomain and parent domain provided', function() {
-      expect(Domain.removeFromList('sub.example.com', domains)).to.eql(['alt.example.com', 'another.sample.com']);
+    it('should give a domain with exact domain match', function() {
+      let cfg = new WebConfig({ domains: domains });
+      let hostname = 'www.example.com';
+      let domain = Domain.byHostname(hostname, cfg.domains);
+      expect(domain.advanced).to.be.undefined;
+      expect(domain.disabled).to.be.true;
+      expect(domain.cfg.disabled).to.be.true;
+      expect(domain.enabled).to.be.undefined;
+      expect(domain.wordlist).to.be.undefined;
+      expect(domain.audioList).to.be.undefined;
+      expect(domain.cfgKey).to.eq(hostname);
     });
 
-    it('should only remove the specific subdomain when no matching parent', function() {
-      expect(Domain.removeFromList('another.sample.com', domains)).to.eql(['example.com', 'sub.example.com', 'alt.example.com']);
+    it('should give a parent domain for subdomain', function() {
+      let cfg = new WebConfig({ domains: domains });
+      let hostname = 'sub.another.com';
+      let domain = Domain.byHostname(hostname, cfg.domains);
+      expect(domain.advanced).to.be.true;
+      expect(domain.cfg.adv).to.be.true;
+      expect(domain.disabled).to.be.undefined;
+      expect(domain.enabled).to.be.undefined;
+      expect(domain.wordlist).to.be.undefined;
+      expect(domain.audioList).to.be.undefined;
+      expect(domain.cfgKey).to.eq('another.com');
     });
+  });
 
-    it('should not remove any domains when no matches are found', function() {
-      expect(Domain.removeFromList('sub.sample.com', domains)).to.eql(domains);
+  describe('.findDomainKey()', function() {
+    let cfg = new WebConfig({ domains: domains });
+    it('should return an exact match', function() { expect(Domain.findDomainKey('www.example.com', cfg.domains)).to.eq('www.example.com'); });
+    it('should match a subdomain of a parent', function() { expect(Domain.findDomainKey('sub.another.com', cfg.domains)).to.eq('another.com'); });
+    it('return undefined if no match', function() { expect(Domain.findDomainKey('nowhere.com', cfg.domains)).to.be.undefined; });
+  });
+
+  describe('.sortedKeys()', function() {
+    let cfg = new WebConfig({ domains: domains });
+    it('should sort domains by parent', function() {
+      expect(Domain.sortedKeys(cfg.domains)).to.eql(['another.com', 'a.example.com', 'www.example.com', 'abc.zoo.edu']);
+    });
+  });
+
+  describe('updateCfg()', function() {
+    it('should update domain.cfg', function() {
+      let domain = new Domain('new.domain.com');
+      domain.advanced = true;
+      expect(domain.cfg.adv).to.be.undefined;
+      domain.updateCfg();
+      expect(domain.cfg.adv).to.be.true;
+    });
+  });
+
+  describe('updateFromCfg()', function() {
+    it('should set domain attributes from domain.cfg', function() {
+      let domain = new Domain('new.domain.com');
+      domain.cfg.adv = true;
+      expect(domain.advanced).to.be.undefined;
+      domain.updateFromCfg();
+      expect(domain.advanced).to.be.true;
     });
   });
 });

--- a/test/lib/config.spec.js
+++ b/test/lib/config.spec.js
@@ -11,7 +11,7 @@ describe('Config', function() {
     });
 
     it('should create a new Config instance with the provided data', function() {
-      let config = new Config({censorCharacter: '-'});
+      let config = new Config({ censorCharacter: '-' });
       expect(config instanceof Config).to.equal(true);
       expect(config.censorCharacter).to.equal('-');
       expect(config.censorFixedLength).to.equal(0);
@@ -31,7 +31,7 @@ describe('Config', function() {
     });
 
     it('should add a new word to the config with provided options', function() {
-      let wordOptions = {matchMethod: 1, repeat: true, sub: 'Older-word'};
+      let wordOptions = { matchMethod: 1, repeat: true, sub: 'Older-word' };
       expect(config.addWord('newer-word', wordOptions)).to.equal(true);
       expect(Object.keys(config.words)).to.include('newer-word');
       expect(config.words['newer-word'].matchMethod).to.equal(wordOptions.matchMethod);
@@ -58,14 +58,14 @@ describe('Config', function() {
     config.words = Object.assign({}, Config._defaultWords);
 
     it('should return the repeat option for a word', function() {
-      config.words['newWord'] = {matchMethod: config.defaultWordMatchMethod, repeat: true, words: []};
+      config.words['newWord'] = { matchMethod: config.defaultWordMatchMethod, repeat: true, words: [] };
       expect(config.repeatForWord('newWord')).to.eql(true);
-      config.words['anotherNewWord'] = {matchMethod: config.defaultWordMatchMethod, repeat: false, words: []};
+      config.words['anotherNewWord'] = { matchMethod: config.defaultWordMatchMethod, repeat: false, words: [] };
       expect(config.repeatForWord('anotherNewWord')).to.eql(false);
     });
 
     it('should return the default word repeat when not present on word', function() {
-      config.words['evenAnotherWord'] = {matchMethod: config.defaultWordMatchMethod, words: []};
+      config.words['evenAnotherWord'] = { matchMethod: config.defaultWordMatchMethod, words: [] };
       expect(config.repeatForWord('evenAnotherWord')).to.eql(config.defaultWordRepeat);
     });
   });
@@ -75,7 +75,7 @@ describe('Config', function() {
     config.words = Object.assign({}, Config._defaultWords);
 
     it('should sanitize words', function() {
-      config.words['newWord '] = {matchMethod: config.defaultWordMatchMethod, repeat: config.defaultWordRepeat, words: []};
+      config.words['newWord '] = { matchMethod: config.defaultWordMatchMethod, repeat: config.defaultWordRepeat, words: [] };
       expect(Object.keys(config.words)).to.include('newWord ');
       expect(Object.keys(config.words)).to.not.include('newword');
       config.sanitizeWords();

--- a/test/lib/filter.spec.js
+++ b/test/lib/filter.spec.js
@@ -119,7 +119,7 @@ describe('Filter', () => {
 
         it('Ending with punctuation', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: {'this!': { matchMethod: 1 }}, filterMethod: 0, censorCharacter: '_', globalMatchMethod: 3, preserveFirst: false });
+          filter.cfg = new Config({ words: { 'this!': { matchMethod: 1 } }, filterMethod: 0, censorCharacter: '_', globalMatchMethod: 3, preserveFirst: false });
           filter.init();
           expect(filter.replaceText('I love allthis! Do you?')).to.equal('I love all_____ Do you?');
           expect(filter.replaceText('I love this! Do you?')).to.equal('I love _____ Do you?');
@@ -138,7 +138,7 @@ describe('Filter', () => {
 
         it('Ending with punctuation', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: {'this!': { matchMethod: 2 }}, filterMethod: 0, censorCharacter: '_', globalMatchMethod: 3, preserveFirst: false });
+          filter.cfg = new Config({ words: { 'this!': { matchMethod: 2 } }, filterMethod: 0, censorCharacter: '_', globalMatchMethod: 3, preserveFirst: false });
           filter.init();
           expect(filter.replaceText('I love allthis! Do you?')).to.equal('I love ________ Do you?');
           expect(filter.replaceText('I love this! Do you?')).to.equal('I love _____ Do you?');
@@ -377,7 +377,7 @@ describe('Filter', () => {
 
         it('Ending with punctuation', () => {
           let filter = new Filter;
-          filter.cfg = new Config({filterMethod: 2, globalMatchMethod: 3, words: {'this!': { matchMethod: 0, repeat: false }}});
+          filter.cfg = new Config({ filterMethod: 2, globalMatchMethod: 3, words: { 'this!': { matchMethod: 0, repeat: false } } });
           filter.init();
           expect(filter.replaceText('I love This! Do you?')).to.equal('I love Do you?');
           expect(filter.replaceText('I love this!')).to.equal('I love');
@@ -404,7 +404,7 @@ describe('Filter', () => {
 
         it('Ending with punctuation', () => {
           let filter = new Filter;
-          filter.cfg = new Config({filterMethod: 2, globalMatchMethod: 3, words: {'this!': { matchMethod: 1, repeat: false }}});
+          filter.cfg = new Config({ filterMethod: 2, globalMatchMethod: 3, words: { 'this!': { matchMethod: 1, repeat: false } } });
           filter.init();
           expect(filter.replaceText('I love allthis! Do you?')).to.equal('I love Do you?');
           expect(filter.replaceText('I love this! Do you?')).to.equal('I love Do you?');

--- a/test/lib/helper.spec.js
+++ b/test/lib/helper.spec.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-import { dynamicList, escapeHTML, getVersion, isVersionOlder, removeFromArray } from '../built/lib/helper';
+import { escapeHTML, getVersion, isVersionOlder, removeFromArray } from '../built/lib/helper';
 
 const array = ['a', 'needle', 'in', 'a', 'large', 'haystack'];
 

--- a/test/lib/word.spec.js
+++ b/test/lib/word.spec.js
@@ -1,57 +1,51 @@
 const expect = require('chai').expect;
+import Config from '../built/lib/config';
 import Word from '../built/lib/word';
 
 describe('Word', function() {
   describe('Regular Expressions', function() {
     describe('Exact Matching', function() {
       it('should build RegExp', function() {
-        Word.initWords({'word': {matchMethod: 0}}, {filterMethod: 0}); // TODO: Shouldn't need filtermethod
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/\bword\b/gi);
+        let word = new Word('word', {matchMethod: 0}, Config._defaults);
+        expect(word.regExp).to.eql(/\bword\b/gi);
       });
 
       it('should build RegExp with matchRepeated', function() {
-        Word.initWords({'word': {matchMethod: 0, repeat: true}}, {filterMethod: 0}); // TODO: Shouldn't need filtermethod
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/\bw+o+r+d+\b/gi);
+        let word = new Word('word', {matchMethod: 0, repeat: true}, Config._defaults);
+        expect(word.regExp).to.eql(/\bw+o+r+d+\b/gi);
       });
 
       it('should throw exception for invalid RegExp', function() {
         expect(() => {
-          let word = new Word(null, {});
-          word.buildRegexp();
+          new Word(null, {}, {});
         }).to.throw();
       });
 
       it('should build RegExp with ending punctuation', function() {
-        Word.initWords({'word!': {matchMethod: 0}});
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0].unicode).to.eql(false);
-        expect(wordRegExps[0]).to.eql(/(^|\s)(word!)(\s|$)/gi);
+        let word = new Word('word!', {matchMethod: 0}, Config._defaults);
+        expect(word.unicode).to.eql(false);
+        expect(word.regExp).to.eql(/(^|\s)(word!)(\s|$)/gi);
       });
 
       it('should build RegExp with matchSeparators and matchRepeated', function() {
-        Word.initWords({word: {matchMethod: 0, repeat: true, separators: true}});
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/\bw+[-_ ]*o+[-_ ]*r+[-_ ]*d+\b/gi);
+        let word = new Word('word', {matchMethod: 0, repeat: true, separators: true}, Config._defaults);
+        expect(word.regExp).to.eql(/\bw+[-_ ]*o+[-_ ]*r+[-_ ]*d+\b/gi);
       });
 
       // Work around for lack of word boundary support for unicode characters
       describe('Unicode', function() {
         it('should use workaround for UTF word boundaries', function() {
-          Word.initWords({'врата': {matchMethod: 0}});
-          let wordRegExps = Word.regExps;
-          expect(wordRegExps[0].unicode).to.eql(true);
-          expect(wordRegExps[0]).to.eql(
+          let word = new Word('врата', {matchMethod: 0}, Config._defaults);
+          expect(word.unicode).to.eql(true);
+          expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]+)(врата)([\\s.,\'"+!?|-]+|$)', 'giu')
           );
         });
 
         it('should use workaround for UTF word boundaries with matchRepeated', function() {
-          Word.initWords({'врата': {matchMethod: 0, repeat: true}});
-          let wordRegExps = Word.regExps;
-          expect(wordRegExps[0].unicode).to.eql(true);
-          expect(wordRegExps[0]).to.eql(
+          let word = new Word('врата', {matchMethod: 0, repeat: true}, Config._defaults);
+          expect(word.unicode).to.eql(true);
+          expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]+)(в+р+а+т+а+)([\\s.,\'"+!?|-]+|$)', 'giu')
           );
         });
@@ -60,65 +54,56 @@ describe('Word', function() {
 
     describe('Partial Match', function() {
       it('should build RegExp', function() {
-        Word.initWords({word: {matchMethod: 1}});
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/word/gi);
+        let word = new Word('word', {matchMethod: 1}, Config._defaults);
+        expect(word.regExp).to.eql(/word/gi);
       });
 
       it('should build RegExp with matchRepeated', function() {
-        Word.initWords({word: {matchMethod: 1, repeat: true}});
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/w+o+r+d+/gi);
+        let word = new Word('word', {matchMethod: 1, repeat: true}, Config._defaults);
+        expect(word.regExp).to.eql(/w+o+r+d+/gi);
       });
 
       it('should build RegExp with matchSeparators', function() {
-        Word.initWords({word: {matchMethod: 1, separators: true}});
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/w[-_ ]*o[-_ ]*r[-_ ]*d/gi);
+        let word = new Word('word', {matchMethod: 1, separators: true}, Config._defaults);
+        expect(word.regExp).to.eql(/w[-_ ]*o[-_ ]*r[-_ ]*d/gi);
       });
 
       it('should build RegExp with matchSeparators and matchRepeated', function() {
-        Word.initWords({word: {matchMethod: 1, repeat: true, separators: true}});
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/w+[-_ ]*o+[-_ ]*r+[-_ ]*d+/gi);
+        let word = new Word('word', {matchMethod: 1, repeat: true, separators: true}, Config._defaults);
+        expect(word.regExp).to.eql(/w+[-_ ]*o+[-_ ]*r+[-_ ]*d+/gi);
       });
     });
 
     describe('Remove Exact', function() {
       it('should build RegExp', function() {
-        Word.initWords({word: {matchMethod: 0}}, {filterMethod: 2});
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/\s?\bword\b\s?/gi);
+        let word = new Word('word', {matchMethod: 0, _filterMethod: 2}, Config._defaults);
+        expect(word.regExp).to.eql(/\s?\bword\b\s?/gi);
       });
 
       it('should build RegExp with matchRepeated', function() {
-        Word.initWords({word: {matchMethod: 0, repeat: true}}, {filterMethod: 2});
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/\s?\bw+o+r+d+\b\s?/gi);
+        let word = new Word('word', {matchMethod: 0, repeat: true, _filterMethod: 2}, Config._defaults);
+        expect(word.regExp).to.eql(/\s?\bw+o+r+d+\b\s?/gi);
       });
 
       it('should build RegExp with ending punctuation', function() {
-        Word.initWords({'word!': {matchMethod: 0}}, {filterMethod: 2});
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/(^|\s)(word!)(\s|$)/gi);
+        let word = new Word('word!', {matchMethod: 0, _filterMethod: 2}, Config._defaults);
+        expect(word.regExp).to.eql(/(^|\s)(word!)(\s|$)/gi);
       });
 
       // Work around for lack of word boundary support for unicode characters
       describe('Unicode', function() {
         it('should build RegExp', function() {
-          Word.initWords({'куче': {matchMethod: 0}}, {filterMethod: 2});
-          let wordRegExps = Word.regExps;
-          expect(wordRegExps[0].unicode).to.eql(true);
-          expect(wordRegExps[0]).to.eql(
+          let word = new Word('куче', {matchMethod: 0, _filterMethod: 2}, Config._defaults);
+          expect(word.unicode).to.eql(true);
+          expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-])(куче)([\\s.,\'"+!?|-]|$)', 'giu')
           );
         });
 
         it('should build RegExp with matchRepeated', function() {
-          Word.initWords({'куче': {matchMethod: 0, repeat: true}}, {filterMethod: 2});
-          let wordRegExps = Word.regExps;
-          expect(wordRegExps[0].unicode).to.eql(true);
-          expect(wordRegExps[0]).to.eql(
+          let word = new Word('куче', {matchMethod: 0, repeat: true, _filterMethod: 2}, Config._defaults);
+          expect(word.unicode).to.eql(true);
+          expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-])(к+у+ч+е+)([\\s.,\'"+!?|-]|$)', 'giu')
           );
         });
@@ -127,39 +112,34 @@ describe('Word', function() {
 
     describe('Remove Partial Match', function() {
       it('should build RegExp', function() {
-        Word.initWords({'word': {matchMethod: 1}}, {filterMethod: 2});
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/\s?\b[\w-]*word[\w-]*\b\s?/gi);
+        let word = new Word('word', {matchMethod: 1}, Object.assign(Config._defaults, {filterMethod: 2}));
+        expect(word.regExp).to.eql(/\s?\b[\w-]*word[\w-]*\b\s?/gi);
       });
 
       it('should build RegExp with matchRepeated', function() {
-        Word.initWords({'word': {matchMethod: 1, repeat: true}}, {filterMethod: 2});
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/\s?\b[\w-]*w+o+r+d+[\w-]*\b\s?/gi);
+        let word = new Word('word', {matchMethod: 1, repeat: true}, Object.assign(Config._defaults, {filterMethod: 2}));
+        expect(word.regExp).to.eql(/\s?\b[\w-]*w+o+r+d+[\w-]*\b\s?/gi);
       });
 
       it('should build RegExp with ending punctuation', function() {
-        Word.initWords({'word!': {matchMethod: 1}}, {filterMethod: 2});
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/(^|\s)([\w-]*word![\w-]*)(\s|$)/gi);
+        let word = new Word('word!', {matchMethod: 1}, Object.assign(Config._defaults, {filterMethod: 2}));
+        expect(word.regExp).to.eql(/(^|\s)([\w-]*word![\w-]*)(\s|$)/gi);
       });
 
       // Work around for lack of word boundary support for unicode characters
       describe('Unicode', function() {
         it('should build RegExp', function() {
-          Word.initWords({'куче': {matchMethod: 1}}, {filterMethod: 2});
-          let wordRegExps = Word.regExps;
-          expect(wordRegExps[0].unicode).to.eql(true);
-          expect(wordRegExps[0]).to.eql(
+          let word = new Word('куче', {matchMethod: 1}, Object.assign(Config._defaults, {filterMethod: 2}));
+          expect(word.unicode).to.eql(true);
+          expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]?)([\\w-]*куче[\\w-]*)([\\s.,\'"+!?|-]?|$)', 'giu')
           );
         });
 
         it('should build RegExp with matchRepeated', function() {
-          Word.initWords({'куче': {matchMethod: 1, repeat: true}}, {filterMethod: 2});
-          let wordRegExps = Word.regExps;
-          expect(wordRegExps[0].unicode).to.eql(true);
-          expect(wordRegExps[0]).to.eql(
+          let word = new Word('куче', {matchMethod: 1, repeat: true}, Object.assign(Config._defaults, {filterMethod: 2}));
+          expect(word.unicode).to.eql(true);
+          expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]?)([\\w-]*к+у+ч+е+[\\w-]*)([\\s.,\'"+!?|-]?|$)', 'giu')
           );
         });
@@ -168,48 +148,42 @@ describe('Word', function() {
 
     describe('Whole Match', function() {
       it('should build RegExp', function() {
-        Word.initWords({'word': {matchMethod: 2}});
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/\b[\w-]*word[\w-]*\b/gi);
+        let word = new Word('word', {matchMethod: 2}, Config._defaults);
+        expect(word.regExp).to.eql(/\b[\w-]*word[\w-]*\b/gi);
       });
 
       it('should build RegExp with matchRepeated', function() {
-        Word.initWords({'word': {matchMethod: 2, repeat: true}});
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/\b[\w-]*w+o+r+d+[\w-]*\b/gi);
+        let word = new Word('word', {matchMethod: 2, repeat: true}, Config._defaults);
+        expect(word.regExp).to.eql(/\b[\w-]*w+o+r+d+[\w-]*\b/gi);
       });
 
       it('should build RegExp with ending punctuation', function() {
-        Word.initWords({'word!': {matchMethod: 2}});
-        let wordRegExps = Word.regExps;
-        expect(wordRegExps[0]).to.eql(/(^|\s)([\S]*word![\S]*)(\s|$)/gi);
+        let word = new Word('word!', {matchMethod: 2}, Config._defaults);
+        expect(word.regExp).to.eql(/(^|\s)([\S]*word![\S]*)(\s|$)/gi);
       });
 
       // Work around for lack of word boundary support for unicode characters
       describe('Unicode', function() {
         it('should build RegExp', function() {
-          Word.initWords({'куче': {matchMethod: 2}});
-          let wordRegExps = Word.regExps;
-          expect(wordRegExps[0].unicode).to.eql(true);
-          expect(wordRegExps[0]).to.eql(
+          let word = new Word('куче', {matchMethod: 2}, Config._defaults);
+          expect(word.unicode).to.eql(true);
+          expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]*)([\\S]*куче[\\S]*)([\\s.,\'"+!?|-]*|$)', 'giu')
           );
         });
 
         it('should build RegExp with matchRepeated', function() {
-          Word.initWords({'куче': {matchMethod: 2, repeat: true}});
-          let wordRegExps = Word.regExps;
-          expect(wordRegExps[0].unicode).to.eql(true);
-          expect(wordRegExps[0]).to.eql(
+          let word = new Word('куче', {matchMethod: 2, repeat: true}, Config._defaults);
+          expect(word.unicode).to.eql(true);
+          expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]*)([\\S]*к+у+ч+е+[\\S]*)([\\s.,\'"+!?|-]*|$)', 'giu')
           );
         });
 
-        it('should build RegExp with matchSeparators and matchRepeated', function() {
-          Word.initWords({'куче': {matchMethod: 2, repeat: true, separators: true}});
-          let wordRegExps = Word.regExps;
-          expect(wordRegExps[0].unicode).to.eql(true);
-          expect(wordRegExps[0]).to.eql(
+        it('should build RegExp with matchRepeated and matchSeparators', function() {
+          let word = new Word('куче', {matchMethod: 2, repeat: true, separators: true}, Config._defaults);
+          expect(word.unicode).to.eql(true);
+          expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]*)([\\S]*к+[-_ ]*у+[-_ ]*ч+[-_ ]*е+[\\S]*)([\\s.,\'"+!?|-]*|$)', 'giu')
           );
         });

--- a/test/lib/word.spec.js
+++ b/test/lib/word.spec.js
@@ -6,12 +6,12 @@ describe('Word', function() {
   describe('Regular Expressions', function() {
     describe('Exact Matching', function() {
       it('should build RegExp', function() {
-        let word = new Word('word', {matchMethod: 0}, Config._defaults);
+        let word = new Word('word', { matchMethod: 0 }, Config._defaults);
         expect(word.regExp).to.eql(/\bword\b/gi);
       });
 
       it('should build RegExp with matchRepeated', function() {
-        let word = new Word('word', {matchMethod: 0, repeat: true}, Config._defaults);
+        let word = new Word('word', { matchMethod: 0, repeat: true }, Config._defaults);
         expect(word.regExp).to.eql(/\bw+o+r+d+\b/gi);
       });
 
@@ -22,20 +22,20 @@ describe('Word', function() {
       });
 
       it('should build RegExp with ending punctuation', function() {
-        let word = new Word('word!', {matchMethod: 0}, Config._defaults);
+        let word = new Word('word!', { matchMethod: 0 }, Config._defaults);
         expect(word.unicode).to.eql(false);
         expect(word.regExp).to.eql(/(^|\s)(word!)(\s|$)/gi);
       });
 
       it('should build RegExp with matchSeparators and matchRepeated', function() {
-        let word = new Word('word', {matchMethod: 0, repeat: true, separators: true}, Config._defaults);
+        let word = new Word('word', { matchMethod: 0, repeat: true, separators: true }, Config._defaults);
         expect(word.regExp).to.eql(/\bw+[-_ ]*o+[-_ ]*r+[-_ ]*d+\b/gi);
       });
 
       // Work around for lack of word boundary support for unicode characters
       describe('Unicode', function() {
         it('should use workaround for UTF word boundaries', function() {
-          let word = new Word('врата', {matchMethod: 0}, Config._defaults);
+          let word = new Word('врата', { matchMethod: 0 }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]+)(врата)([\\s.,\'"+!?|-]+|$)', 'giu')
@@ -43,7 +43,7 @@ describe('Word', function() {
         });
 
         it('should use workaround for UTF word boundaries with matchRepeated', function() {
-          let word = new Word('врата', {matchMethod: 0, repeat: true}, Config._defaults);
+          let word = new Word('врата', { matchMethod: 0, repeat: true }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]+)(в+р+а+т+а+)([\\s.,\'"+!?|-]+|$)', 'giu')
@@ -54,46 +54,46 @@ describe('Word', function() {
 
     describe('Partial Match', function() {
       it('should build RegExp', function() {
-        let word = new Word('word', {matchMethod: 1}, Config._defaults);
+        let word = new Word('word', { matchMethod: 1 }, Config._defaults);
         expect(word.regExp).to.eql(/word/gi);
       });
 
       it('should build RegExp with matchRepeated', function() {
-        let word = new Word('word', {matchMethod: 1, repeat: true}, Config._defaults);
+        let word = new Word('word', { matchMethod: 1, repeat: true }, Config._defaults);
         expect(word.regExp).to.eql(/w+o+r+d+/gi);
       });
 
       it('should build RegExp with matchSeparators', function() {
-        let word = new Word('word', {matchMethod: 1, separators: true}, Config._defaults);
+        let word = new Word('word', { matchMethod: 1, separators: true }, Config._defaults);
         expect(word.regExp).to.eql(/w[-_ ]*o[-_ ]*r[-_ ]*d/gi);
       });
 
       it('should build RegExp with matchSeparators and matchRepeated', function() {
-        let word = new Word('word', {matchMethod: 1, repeat: true, separators: true}, Config._defaults);
+        let word = new Word('word', { matchMethod: 1, repeat: true, separators: true }, Config._defaults);
         expect(word.regExp).to.eql(/w+[-_ ]*o+[-_ ]*r+[-_ ]*d+/gi);
       });
     });
 
     describe('Remove Exact', function() {
       it('should build RegExp', function() {
-        let word = new Word('word', {matchMethod: 0, _filterMethod: 2}, Config._defaults);
+        let word = new Word('word', { matchMethod: 0, _filterMethod: 2 }, Config._defaults);
         expect(word.regExp).to.eql(/\s?\bword\b\s?/gi);
       });
 
       it('should build RegExp with matchRepeated', function() {
-        let word = new Word('word', {matchMethod: 0, repeat: true, _filterMethod: 2}, Config._defaults);
+        let word = new Word('word', { matchMethod: 0, repeat: true, _filterMethod: 2 }, Config._defaults);
         expect(word.regExp).to.eql(/\s?\bw+o+r+d+\b\s?/gi);
       });
 
       it('should build RegExp with ending punctuation', function() {
-        let word = new Word('word!', {matchMethod: 0, _filterMethod: 2}, Config._defaults);
+        let word = new Word('word!', { matchMethod: 0, _filterMethod: 2 }, Config._defaults);
         expect(word.regExp).to.eql(/(^|\s)(word!)(\s|$)/gi);
       });
 
       // Work around for lack of word boundary support for unicode characters
       describe('Unicode', function() {
         it('should build RegExp', function() {
-          let word = new Word('куче', {matchMethod: 0, _filterMethod: 2}, Config._defaults);
+          let word = new Word('куче', { matchMethod: 0, _filterMethod: 2 }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-])(куче)([\\s.,\'"+!?|-]|$)', 'giu')
@@ -101,7 +101,7 @@ describe('Word', function() {
         });
 
         it('should build RegExp with matchRepeated', function() {
-          let word = new Word('куче', {matchMethod: 0, repeat: true, _filterMethod: 2}, Config._defaults);
+          let word = new Word('куче', { matchMethod: 0, repeat: true, _filterMethod: 2 }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-])(к+у+ч+е+)([\\s.,\'"+!?|-]|$)', 'giu')
@@ -112,24 +112,24 @@ describe('Word', function() {
 
     describe('Remove Partial Match', function() {
       it('should build RegExp', function() {
-        let word = new Word('word', {matchMethod: 1}, Object.assign(Config._defaults, {filterMethod: 2}));
+        let word = new Word('word', { matchMethod: 1 }, Object.assign(Config._defaults, { filterMethod: 2 }));
         expect(word.regExp).to.eql(/\s?\b[\w-]*word[\w-]*\b\s?/gi);
       });
 
       it('should build RegExp with matchRepeated', function() {
-        let word = new Word('word', {matchMethod: 1, repeat: true}, Object.assign(Config._defaults, {filterMethod: 2}));
+        let word = new Word('word', { matchMethod: 1, repeat: true }, Object.assign(Config._defaults, { filterMethod: 2 }));
         expect(word.regExp).to.eql(/\s?\b[\w-]*w+o+r+d+[\w-]*\b\s?/gi);
       });
 
       it('should build RegExp with ending punctuation', function() {
-        let word = new Word('word!', {matchMethod: 1}, Object.assign(Config._defaults, {filterMethod: 2}));
+        let word = new Word('word!', { matchMethod: 1 }, Object.assign(Config._defaults, { filterMethod: 2 }));
         expect(word.regExp).to.eql(/(^|\s)([\w-]*word![\w-]*)(\s|$)/gi);
       });
 
       // Work around for lack of word boundary support for unicode characters
       describe('Unicode', function() {
         it('should build RegExp', function() {
-          let word = new Word('куче', {matchMethod: 1}, Object.assign(Config._defaults, {filterMethod: 2}));
+          let word = new Word('куче', { matchMethod: 1 }, Object.assign(Config._defaults, { filterMethod: 2 }));
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]?)([\\w-]*куче[\\w-]*)([\\s.,\'"+!?|-]?|$)', 'giu')
@@ -137,7 +137,7 @@ describe('Word', function() {
         });
 
         it('should build RegExp with matchRepeated', function() {
-          let word = new Word('куче', {matchMethod: 1, repeat: true}, Object.assign(Config._defaults, {filterMethod: 2}));
+          let word = new Word('куче', { matchMethod: 1, repeat: true }, Object.assign(Config._defaults, { filterMethod: 2 }));
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]?)([\\w-]*к+у+ч+е+[\\w-]*)([\\s.,\'"+!?|-]?|$)', 'giu')
@@ -148,24 +148,24 @@ describe('Word', function() {
 
     describe('Whole Match', function() {
       it('should build RegExp', function() {
-        let word = new Word('word', {matchMethod: 2}, Config._defaults);
+        let word = new Word('word', { matchMethod: 2 }, Config._defaults);
         expect(word.regExp).to.eql(/\b[\w-]*word[\w-]*\b/gi);
       });
 
       it('should build RegExp with matchRepeated', function() {
-        let word = new Word('word', {matchMethod: 2, repeat: true}, Config._defaults);
+        let word = new Word('word', { matchMethod: 2, repeat: true }, Config._defaults);
         expect(word.regExp).to.eql(/\b[\w-]*w+o+r+d+[\w-]*\b/gi);
       });
 
       it('should build RegExp with ending punctuation', function() {
-        let word = new Word('word!', {matchMethod: 2}, Config._defaults);
+        let word = new Word('word!', { matchMethod: 2 }, Config._defaults);
         expect(word.regExp).to.eql(/(^|\s)([\S]*word![\S]*)(\s|$)/gi);
       });
 
       // Work around for lack of word boundary support for unicode characters
       describe('Unicode', function() {
         it('should build RegExp', function() {
-          let word = new Word('куче', {matchMethod: 2}, Config._defaults);
+          let word = new Word('куче', { matchMethod: 2 }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]*)([\\S]*куче[\\S]*)([\\s.,\'"+!?|-]*|$)', 'giu')
@@ -173,7 +173,7 @@ describe('Word', function() {
         });
 
         it('should build RegExp with matchRepeated', function() {
-          let word = new Word('куче', {matchMethod: 2, repeat: true}, Config._defaults);
+          let word = new Word('куче', { matchMethod: 2, repeat: true }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]*)([\\S]*к+у+ч+е+[\\S]*)([\\s.,\'"+!?|-]*|$)', 'giu')
@@ -181,7 +181,7 @@ describe('Word', function() {
         });
 
         it('should build RegExp with matchRepeated and matchSeparators', function() {
-          let word = new Word('куче', {matchMethod: 2, repeat: true, separators: true}, Config._defaults);
+          let word = new Word('куче', { matchMethod: 2, repeat: true, separators: true }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]*)([\\S]*к+[-_ ]*у+[-_ ]*ч+[-_ ]*е+[\\S]*)([\\s.,\'"+!?|-]*|$)', 'giu')

--- a/test/lib/wordlist.spec.js
+++ b/test/lib/wordlist.spec.js
@@ -1,0 +1,45 @@
+const expect = require('chai').expect;
+import Wordlist from '../built/lib/wordlist';
+
+const testWords = {
+  'example': { lists: [1], matchMethod: 0, repeat: true, sub: 'demo' },
+  'placeholder': { lists: [1,2], matchMethod: 0, repeat: false, sub: 'variable' },
+  'sample': { lists: [2], matchMethod: 1, repeat: false, sub: 'piece' },
+  'word': { matchMethod: 2, repeat: true, sub: 'idea' }
+};
+
+describe('Wordlist', function() {
+  describe('constructor', function() {
+    it('should build a new wordlist with all words', function() {
+      let wordlist = new Wordlist({ words: testWords }, 0);
+      expect(wordlist.all.length).to.equal(4);
+      expect(wordlist.list).to.eql(['placeholder', 'example', 'sample', 'word']);
+      expect(wordlist.regExps.length).to.equal(4);
+    });
+
+    it('should build a new wordlist assigned to wordlist 1', function() {
+      let wordlist = new Wordlist({ words: testWords }, 1);
+      expect(wordlist.all.length).to.equal(3);
+      expect(wordlist.list).to.eql(['placeholder', 'example', 'word']);
+      expect(wordlist.regExps.length).to.equal(3);
+    });
+  });
+
+  describe('find()', function() {
+    it('by name (string)', function() {
+      let wordlist = new Wordlist({ words: testWords }, 0);
+      expect(wordlist.find('word').sub).to.equal('idea');
+    });
+
+    it('by id', function() {
+      let wordlist = new Wordlist({ words: testWords }, 2);
+      expect(wordlist.find(1).value).to.equal('sample');
+    });
+
+    it('non-existent word', function() {
+      let wordlist = new Wordlist({ words: testWords }, 2);
+      expect(wordlist.find(99)).to.equal(undefined);
+      expect(wordlist.find('non-existent')).to.equal(undefined);
+    });
+  });
+});

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -5,7 +5,7 @@ describe('Page', function() {
   describe('isForbiddenNode()', function() {
     it('should return true when node is editable', function() {
       expect(Page.isForbiddenNode({ isContentEditable: true })).to.equal(true);
-      expect(Page.isForbiddenNode({ parentNode: { isContentEditable: true }})).to.equal(true);
+      expect(Page.isForbiddenNode({ parentNode: { isContentEditable: true } })).to.equal(true);
     });
 
     it('should return false when node is not editable', function() {

--- a/test/webConfig.spec.js
+++ b/test/webConfig.spec.js
@@ -1,29 +1,106 @@
 const expect = require('chai').expect;
-import Config from './built/webConfig';
+import WebConfig from './built/webConfig';
 
 describe('WebConfig', function() {
   it('should throw when no async_params provided', function() {
     expect(() => (new WebConfig)).to.throw();
   });
 
-  describe('combineWords()', function() {
-    let config = new Config(Config._defaults);
-    config.words = Object.assign({}, Config._defaultWords);
+  describe('.combineData()', function() {
+    it('should combine _domain# data', function() {
+      let config = new WebConfig(WebConfig._defaults);
+      delete config.domains;
+      config._splitContainerKeys = ['domains'];
+      config._domains0 = { 'www.example0.com': { 'adv': true } };
+      config._domains1 = { 'www.example1.com': { 'adv': true } };
+      expect(config.domain).to.not.exist;
+      let combinedKeys = WebConfig.combineData(config, 'domains');
+      expect(combinedKeys).to.eql(['_domains0', '_domains1']);
+      expect(config.domains['www.example0.com'].adv).to.be.true;
+      expect(config.domains['www.example1.com'].adv).to.be.true;
+      expect(config._domains0).to.not.exist;
+      expect(config._domains1).to.not.exist;
+    });
 
-    it('should add a new word to the config', function() {
-
+    it('should combine _words# data', function() {
+      let config = new WebConfig(WebConfig._defaults);
+      config._words0 = WebConfig._defaultWords;
+      config._words1 = { 'test': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'tset' } };
+      config._splitContainerKeys = ['words'];
+      expect(config.words).to.not.exist;
+      let combinedKeys = WebConfig.combineData(config, 'words');
+      expect(combinedKeys).to.eql(['_words0', '_words1']);
+      expect(config.words['test'].matchMethod).to.eq(0);
+      expect(config.words[Object.keys(WebConfig._defaultWords)[0]]).to.exist;
+      expect(config.words['undefined']).to.not.exist;
+      expect(config._words0).to.not.exist;
+      expect(config._words1).to.not.exist;
     });
   });
 
-  describe('dataToPersist()', function() {
+
+  describe('.getDataContainerKeys()', function() {
+    it('should return all matches', function() {
+      let config = new WebConfig(WebConfig._defaults);
+      delete config.domains;
+      config._domains0 = { 'www.example0.com': { 'adv': true } };
+      config._domains1 = { 'www.example1.com': { 'adv': true } };
+      expect(WebConfig.getDataContainerKeys(config, 'domains')).to.eql(['_domains0', '_domains1']);
+    });
+
+    it('should return no matches if none', function() {
+      let config = new WebConfig(WebConfig._defaults);
+      expect(WebConfig.getDataContainerKeys(config, 'domains')).to.eql([]);
+    });
   });
 
-  describe('repeatForWord()', function() {
+  describe('ordered()', function() {
+    it('remove "_" prefix values', function() {
+      let config = new WebConfig(WebConfig._defaults);
+      expect(config._splitContainerKeys).to.exist;
+      expect(config.ordered()._splitContainerKeys).to.not.exist;
+    });
   });
 
-  describe('sanitizeWords()', function() {
-  });
+  describe('splitData()', function() {
+    const encoder = new TextEncoder();
 
-  describe('splitWords()', function() {
+    it('should split data on _splittingKeys', function() {
+      let config = new WebConfig(WebConfig._defaults);
+      let domains = {};
+      let domainsLength = 0;
+      let testingMax = WebConfig._maxBytes * 1.1;
+
+      for (let i = 0; domainsLength < testingMax; i++) {
+        domains[`www.example${i}.com`] = { adv: true, wordlist: 2, audioList: 3 };
+        domainsLength = encoder.encode(JSON.stringify(domains)).length;
+      }
+
+      config.domains = domains;
+      let count = Object.keys(config.domains).length;
+      expect(config._domains0).to.be.undefined;
+      let data = config.splitData('domains');
+      expect(Object.keys(data._domains0).length).to.be.gt(0);
+      expect(Object.keys(data._domains0).length).to.be.lt(count);
+      expect(Object.keys(data._domains0).length + Object.keys(data._domains1).length).to.eq(count);
+    });
+
+    it('should not split when under max', function() {
+      let config = new WebConfig(WebConfig._defaults);
+      let domains = {};
+      let domainsLength = 0;
+      let testingMax = WebConfig._maxBytes * 0.5;
+
+      for (let i = 0; domainsLength < testingMax; i++) {
+        domains[`www.example${i}.com`] = { adv: true, wordlist: 2, audioList: 3 };
+        domainsLength = encoder.encode(JSON.stringify(domains)).length;
+      }
+
+      config.domains = domains;
+      let count = Object.keys(config.domains).length;
+      let data = config.splitData('domains');
+      expect(Object.keys(data._domains0).length).to.eq(count);
+      expect(data._domains1).to.be.undefined;
+    });
   });
 });


### PR DESCRIPTION
## ✨  New Features & Updates:
- Add support for different [wordlists](https://github.com/richardfrost/AdvancedProfanityFilter/wiki#wordlists)
- Bulk Word Editor: Edit multple words at the same time! (Also includes bulk importer)
- `globalMatchMethod` is no more. To re-create it, set a default match method and change existing words in the bulk editor

## 🐛 Bugs Fixed:
- afd4429e40cfd4e642760d97eeda2b76af3e1d4d Another update for Amazon Video muting (#183) 

## 🔧 Development:
- Updated/added some tests
- More linting
- Added capability for `WebConfig` to add web-specific config (instead of `Config`)
- Moved from old domain arrays to Domain class-based config (for per-domain wordlists)
- Allow select list of config items to split when saving (currently `words` & `domains`)