### PR TITLE
Fix RegExp match

### DIFF
--- a/src/script/bookmarkletFilter.ts
+++ b/src/script/bookmarkletFilter.ts
@@ -1,3 +1,4 @@
+import Constants from './lib/constants';
 import Domain from './domain';
 import Filter from './lib/filter';
 import Page from './page';
@@ -175,7 +176,7 @@ export default class BookmarkletFilter extends Filter {
   cleanPage() {
     this.cfg = new WebConfig(config);
     this.domain = Domain.byHostname(this.hostname, this.cfg.domains);
-    this.cfg.muteMethod = 1; // Bookmarklet: Force audio muteMethod = 1 (Volume)
+    this.cfg.muteMethod = Constants.MuteMethods.Video; // Bookmarklet: Force video volume mute method
 
     // Use domain-specific settings
     let message: Message = { disabled: (this.cfg.enabledDomainsOnly && !this.domain.enabled) || this.domain.disabled };

--- a/src/script/dataMigration.ts
+++ b/src/script/dataMigration.ts
@@ -1,3 +1,4 @@
+import Constants from './lib/constants';
 import { getVersion, isVersionOlder } from './lib/helper';
 import WebConfig from './webConfig';
 
@@ -63,10 +64,10 @@ export default class DataMigration {
   fixSmartWatch() {
     let cfg = this.cfg;
     let originalWord = 'twat';
-    let originalWordConf = { matchMethod: 1, repeat: true, sub: 'dumbo' };
+    let originalWordConf = { matchMethod: Constants.MatchMethods.Partial, repeat: true, sub: 'dumbo' };
     let update = {
-      twat: { matchMethod: 0, repeat: true, sub: 'dumbo' },
-      twats: { matchMethod: 0, repeat: true, sub: 'dumbos' }
+      twat: { matchMethod: Constants.MatchMethods.Exact, repeat: true, sub: 'dumbo' },
+      twats: { matchMethod: Constants.MatchMethods.Exact, repeat: true, sub: 'dumbos' }
     };
 
     if (
@@ -101,7 +102,7 @@ export default class DataMigration {
         let word = cfg.words[name];
         // Move RegExp from 4 to 3
         if (word.matchMethod === 4) {
-          word.matchMethod = 3;
+          word.matchMethod = Constants.MatchMethods.Regex;
         }
       });
       cfg.remove('globalMatchMethod');

--- a/src/script/lib/config.ts
+++ b/src/script/lib/config.ts
@@ -1,3 +1,5 @@
+import Constants from './constants';
+
 export default class Config {
   censorCharacter: string;
   censorFixedLength: number;
@@ -26,10 +28,10 @@ export default class Config {
     censorCharacter: '*',
     censorFixedLength: 0,
     defaultSubstitution: 'censored',
-    defaultWordMatchMethod: 0,
+    defaultWordMatchMethod: Constants.MatchMethods.Exact,
     defaultWordRepeat: false,
     defaultWordSeparators: false,
-    filterMethod: 1, // ['Censor', 'Substitute', 'Remove'];
+    filterMethod: Constants.FilterMethods.Substitute,
     filterWordList: true,
     iWordWhitelist: [],
     preserveCase: true,
@@ -45,41 +47,38 @@ export default class Config {
   };
 
   static readonly _defaultWords: { [key: string]: WordOptions } = {
-    'ass': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'butt' },
-    'asses': { lists: [], matchMethod: 0, repeat: false, separators: false, sub: 'butts' },
-    'asshole': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'jerk' },
-    'badass': { lists: [], matchMethod: 1, repeat: true, separators: true, sub: 'cool' },
-    'bastard': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'idiot' },
-    'bitch': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'bench' },
-    'cocksucker': { lists: [], matchMethod: 1, repeat: true, separators: true, sub: 'suckup' },
-    'cunt': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'expletive' },
-    'dammit': { lists: [], matchMethod: 1, repeat: false, separators: true, sub: 'dangit' },
-    'damn': { lists: [], matchMethod: 1, repeat: false, separators: false, sub: 'dang' },
-    'dumbass': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'idiot' },
-    'fag': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'gay' },
-    'faggot': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'gay' },
-    'fags': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'gays' },
-    'fuck': { lists: [], matchMethod: 1, repeat: true, separators: true, sub: 'freak' },
-    'goddammit': { lists: [], matchMethod: 1, repeat: true, separators: true, sub: 'dangit' },
-    'hell': { lists: [], matchMethod: 0, repeat: false, separators: false, sub: 'heck' },
-    'jackass': { lists: [], matchMethod: 1, repeat: true, separators: true, sub: 'jerk' },
-    'nigga': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'bruh' },
-    'nigger': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'man' },
-    'niggers': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'people' },
-    'piss': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'pee' },
-    'pissed': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'ticked' },
-    'pussies': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'softies' },
-    'pussy': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'softie' },
-    'shit': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'crap' },
-    'slut': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'tramp' },
-    'tits': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'chest' },
-    'twat': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'dumbo' },
-    'twats': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'dumbos' },
-    'whore': { lists: [], matchMethod: 1, repeat: true, separators: false, sub: 'tramp' },
+    'ass': { lists: [], matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'butt' },
+    'asses': { lists: [], matchMethod: Constants.MatchMethods.Exact, repeat: false, separators: false, sub: 'butts' },
+    'asshole': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: false, sub: 'jerk' },
+    'badass': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: true, sub: 'cool' },
+    'bastard': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: false, sub: 'idiot' },
+    'bitch': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: false, sub: 'bench' },
+    'cocksucker': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: true, sub: 'suckup' },
+    'cunt': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: false, sub: 'expletive' },
+    'dammit': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: false, separators: true, sub: 'dangit' },
+    'damn': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: false, separators: false, sub: 'dang' },
+    'dumbass': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: false, sub: 'idiot' },
+    'fag': { lists: [], matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'gay' },
+    'faggot': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: false, sub: 'gay' },
+    'fags': { lists: [], matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'gays' },
+    'fuck': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: true, sub: 'freak' },
+    'goddammit': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: true, sub: 'dangit' },
+    'hell': { lists: [], matchMethod: Constants.MatchMethods.Exact, repeat: false, separators: false, sub: 'heck' },
+    'jackass': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: true, sub: 'jerk' },
+    'nigga': { lists: [], matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'bruh' },
+    'nigger': { lists: [], matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'man' },
+    'niggers': { lists: [], matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'people' },
+    'piss': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: false, sub: 'pee' },
+    'pissed': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: false, sub: 'ticked' },
+    'pussies': { lists: [], matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'softies' },
+    'pussy': { lists: [], matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'softie' },
+    'shit': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: false, sub: 'crap' },
+    'slut': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: false, sub: 'tramp' },
+    'tits': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: false, sub: 'chest' },
+    'twat': { lists: [], matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'dumbo' },
+    'twats': { lists: [], matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'dumbos' },
+    'whore': { lists: [], matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: false, sub: 'tramp' },
   };
-
-  static readonly _filterMethodNames = ['Censor', 'Substitute', 'Remove'];
-  static readonly _matchMethodNames = ['Exact', 'Partial', 'Whole', 'Regular-Expression'];
 
   constructor(data: object = {}) {
     Object.assign(this, Config._defaults, data);

--- a/src/script/lib/constants.ts
+++ b/src/script/lib/constants.ts
@@ -1,0 +1,20 @@
+export default class Constants {
+  // Named Constants
+  static readonly FilterMethods = { Censor: 0, Substitute: 1, Remove: 2 };
+  static readonly MatchMethods = { Exact: 0, Partial: 1, Whole: 2, Regex: 3 };
+  static readonly MuteMethods = { Tab: 0, Video: 1 };
+  static readonly ShowSubtitles = { All: 0, Filtered: 1, Unfiltered: 2, None: 3 };
+
+  // Helper Functions
+  static filterMethodName(id: number) { return this.nameById(this.FilterMethods, id); }
+  static matchMethodName(id: number) { return this.nameById(this.MatchMethods, id); }
+  static nameById(obj: object, id: number): string {
+    return Object.entries(obj).filter(arr => arr[1] === id)[0][0];
+  }
+
+  static orderedArray(obj: object) {
+    let result = [];
+    Object.values(obj).sort().forEach(id => { result.push(Constants.nameById(obj, id)); });
+    return result;
+  }
+}

--- a/src/script/lib/filter.ts
+++ b/src/script/lib/filter.ts
@@ -1,3 +1,4 @@
+import Constants from './constants';
 import Word from './word';
 import Wordlist from './wordlist';
 import Config from './config';
@@ -41,9 +42,9 @@ export default class Filter {
       if (iWhitelistLength && self.iWhitelist.includes(match.toLowerCase())) { return true; }
 
       // Check for partial match (match may not contain the full whitelisted word)
-      if (word.matchMethod === 1) {
+      if (word.matchMethod === Constants.MatchMethods.Partial) {
         let wordOptions: WordOptions = {
-          matchMethod: 2,
+          matchMethod: Constants.MatchMethods.Whole,
           repeat: false,
           separators: false,
           sub: ''
@@ -90,7 +91,7 @@ export default class Filter {
     // - Remove Filter
     // - Unicode word boundaries (workaround)
     // - Edge punctuation
-    let internalCaptureGroups = (captureGroups.length > 0 && word.matchMethod !== 3);
+    let internalCaptureGroups = (captureGroups.length > 0 && word.matchMethod !== Constants.MatchMethods.Regex);
     if (internalCaptureGroups) { match = captureGroups[1]; }
 
     return { word: word, string: string, match: match, matchStartIndex: matchStartIndex, captureGroups: captureGroups, internalCaptureGroups: internalCaptureGroups };
@@ -109,7 +110,7 @@ export default class Filter {
     let wordlist = self.wordlists[wordlistId];
 
     switch(self.cfg.filterMethod) {
-      case 0: // Censor
+      case Constants.FilterMethods.Censor:
         wordlist.regExps.forEach((regExp, index) => {
           str = str.replace(regExp, function(originalMatch, ...args): string {
             let { word, string, match, matchStartIndex, captureGroups, internalCaptureGroups } = self.matchData(wordlist, index, originalMatch, args);
@@ -135,7 +136,7 @@ export default class Filter {
           });
         });
         break;
-      case 1: // Substitute
+      case Constants.FilterMethods.Substitute:
         wordlist.regExps.forEach((regExp, index) => {
           str = str.replace(regExp, function(originalMatch, ...args): string {
             let { word, string, match, matchStartIndex, captureGroups, internalCaptureGroups } = self.matchData(wordlist, index, originalMatch, args);
@@ -163,7 +164,7 @@ export default class Filter {
           });
         });
         break;
-      case 2: // Remove
+      case Constants.FilterMethods.Remove:
         wordlist.regExps.forEach((regExp, index) => {
           str = str.replace(regExp, function(originalMatch, ...args): string {
             let { word, string, match, matchStartIndex, captureGroups, internalCaptureGroups } = self.matchData(wordlist, index, originalMatch, args);
@@ -172,7 +173,6 @@ export default class Filter {
 
             // Filter
             if (internalCaptureGroups) {
-              match = captureGroups[1];
               if (Word.whitespaceRegExp.test(captureGroups[0]) && Word.whitespaceRegExp.test(captureGroups[2])) { // If both surrounds are whitespace (only need 1)
                 return captureGroups[0];
               } else if (Word.nonWordRegExp.test(captureGroups[0]) || Word.nonWordRegExp.test(captureGroups[2])) { // If there is more than just whitesapce (ex. ',')

--- a/src/script/lib/globals.d.ts
+++ b/src/script/lib/globals.d.ts
@@ -6,6 +6,7 @@ interface AudioRules {
   convertBreaks?: boolean;          // [Element,ElementChild] Convert <br> to '\n'
   dataPropPresent?: string;         // [Element] node.dataset.hasOwnProperty()
   disabled?: boolean;               // [All] Set automatically based on iframe status or missing a required property
+  displayMode?: string;             // [All] 'style', 'empty'
   displayHide?: string;             // [Element,ElementChild] Display style for hiding captions (Default: 'none')
   displaySelector?: string;         // [Element,ElementChild] Alternate selector to hide/show captions
   displayShow?: string;             // [Element,ElementChild] Display style for showing captions (Default: '')

--- a/src/script/lib/globals.d.ts
+++ b/src/script/lib/globals.d.ts
@@ -6,7 +6,6 @@ interface AudioRules {
   convertBreaks?: boolean;          // [Element,ElementChild] Convert <br> to '\n'
   dataPropPresent?: string;         // [Element] node.dataset.hasOwnProperty()
   disabled?: boolean;               // [All] Set automatically based on iframe status or missing a required property
-  displayMode?: string;             // [All] 'style', 'empty'
   displayHide?: string;             // [Element,ElementChild] Display style for hiding captions (Default: 'none')
   displaySelector?: string;         // [Element,ElementChild] Alternate selector to hide/show captions
   displayShow?: string;             // [Element,ElementChild] Display style for showing captions (Default: '')

--- a/src/script/lib/word.ts
+++ b/src/script/lib/word.ts
@@ -58,12 +58,10 @@ export default class Word {
     this.sub = options.sub === undefined ? cfg.defaultSubstitution : options.sub;
     this._filterMethod = options._filterMethod === undefined ? cfg.filterMethod : options._filterMethod;
     this.unicode = Word.containsDoubleByte(word);
-    this.escaped = Word.escapeRegExp(this.value);
+    this.escaped = this.matchMethod === 3 ? this.value : Word.escapeRegExp(this.value); // Don't escape a RegExp
     this.regExp = this.buildRegExp();
   }
 
-  // Word must match exactly (not sub-string)
-  // /\bword\b/gi
   buildRegExp(): RegExp {
     let word = this;
     try {
@@ -122,6 +120,7 @@ export default class Word {
               // Begin or end with punctuation (not \w))
               return new RegExp('(^|\\s)(' + word.processedPhrase() + ')(\\s|$)', word.regexOptions());
             } else {
+              // /\bword\b/gi
               return new RegExp('\\b' + word.processedPhrase() + '\\b', word.regexOptions());
             }
           }

--- a/src/script/lib/word.ts
+++ b/src/script/lib/word.ts
@@ -1,3 +1,4 @@
+import Constants from './constants';
 import Config from './config';
 
 export default class Word {
@@ -58,7 +59,7 @@ export default class Word {
     this.sub = options.sub === undefined ? cfg.defaultSubstitution : options.sub;
     this._filterMethod = options._filterMethod === undefined ? cfg.filterMethod : options._filterMethod;
     this.unicode = Word.containsDoubleByte(word);
-    this.escaped = this.matchMethod === 3 ? this.value : Word.escapeRegExp(this.value); // Don't escape a RegExp
+    this.escaped = this.matchMethod === Constants.MatchMethods.Regex ? this.value : Word.escapeRegExp(this.value); // Don't escape a RegExp
     this.regExp = this.buildRegExp();
   }
 
@@ -66,8 +67,8 @@ export default class Word {
     let word = this;
     try {
       switch(word.matchMethod) {
-        case 1: // Partial: Match any part of a word (sub-string)
-          if (word._filterMethod === 2) { // Filter Method: Remove
+        case Constants.MatchMethods.Partial:
+          if (word._filterMethod === Constants.FilterMethods.Remove) {
             // Match entire word that contains sub-string and surrounding whitespace
             // /\s?\b[\w-]*word[\w-]*\b\s?/gi
             if (word.unicode) {
@@ -83,7 +84,7 @@ export default class Word {
             // /word/gi
             return new RegExp(word.processedPhrase(), word.regexOptions());
           }
-        case 2: // Whole: Match entire word that contains sub-string
+        case Constants.MatchMethods.Whole:
           // /\b[\w-]*word[\w-]*\b/gi
           if (word.unicode) {
             // Work around for lack of word boundary support for unicode characters
@@ -94,14 +95,13 @@ export default class Word {
           } else {
             return new RegExp('\\b[\\w-]*' + word.processedPhrase() + '[\\w-]*\\b', word.regexOptions());
           }
-        case 3: // Regular Expression (Advanced)
+        case Constants.MatchMethods.Regex:
           return new RegExp(word.value, word.regexOptions());
-        case 0: // Exact: Word must match exactly (not sub-string)
+        case Constants.MatchMethods.Exact:
         default:
-          // Filter Method: Remove
           // Match entire word that contains sub-string and surrounding whitespace
           // /\s?\bword\b\s?/gi
-          if (word._filterMethod === 2) { // Remove method
+          if (word._filterMethod === Constants.FilterMethods.Remove) {
             if (word.unicode) {
               // Work around for lack of word boundary support for unicode characters
               // /(^|[\s.,'"+!?|-])(word)([\s.,'"+!?|-]+|$)/giu

--- a/src/script/lib/word.ts
+++ b/src/script/lib/word.ts
@@ -105,7 +105,7 @@ export default class Word {
           } else {
             return new RegExp('\\b[\\w-]*' + word.processedPhrase() + '[\\w-]*\\b', word.regexOptions());
           }
-        case 4: // Regular Expression (Advanced)
+        case 3: // Regular Expression (Advanced)
           return new RegExp(word.value, word.regexOptions());
         case 1: // Partial: Match any part of a word (sub-string)
         default:

--- a/src/script/lib/word.ts
+++ b/src/script/lib/word.ts
@@ -68,7 +68,38 @@ export default class Word {
     let word = this;
     try {
       switch(word.matchMethod) {
+        case 1: // Partial: Match any part of a word (sub-string)
+          if (word._filterMethod === 2) { // Filter Method: Remove
+            // Match entire word that contains sub-string and surrounding whitespace
+            // /\s?\b[\w-]*word[\w-]*\b\s?/gi
+            if (word.unicode) {
+              // Work around for lack of word boundary support for unicode characters
+              // /(^|[\s.,'"+!?|-]?)[\w-]*(word)[\w-]*([\s.,'"+!?|-]?|$)/giu
+              return new RegExp('(^|' + Word._unicodeWordBoundary + '?)([\\w-]*' +  word.processedPhrase() + '[\\w-]*)(' + Word._unicodeWordBoundary + '?|$)', word.regexOptions());
+            } else if (word.hasEdgePunctuation()) { // Begin or end with punctuation (not \w))
+              return new RegExp('(^|\\s)([\\w-]*' +  word.processedPhrase() + '[\\w-]*)(\\s|$)', word.regexOptions());
+            } else {
+              return new RegExp('\\s?\\b[\\w-]*' +  word.processedPhrase() + '[\\w-]*\\b\\s?', word.regexOptions());
+            }
+          } else {
+            // /word/gi
+            return new RegExp(word.processedPhrase(), word.regexOptions());
+          }
+        case 2: // Whole: Match entire word that contains sub-string
+          // /\b[\w-]*word[\w-]*\b/gi
+          if (word.unicode) {
+            // Work around for lack of word boundary support for unicode characters
+            // (^|[\s.,'"+!?|-]*)([\S]*куче[\S]*)([\s.,'"+!?|-]*|$)/giu
+            return new RegExp('(^|' + Word._unicodeWordBoundary + '*)([\\S]*' + word.processedPhrase() + '[\\S]*)(' + Word._unicodeWordBoundary + '*|$)', word.regexOptions());
+          } else if (word.hasEdgePunctuation()) { // Begin or end with punctuation (not \w))
+            return new RegExp('(^|\\s)([\\S]*' + word.processedPhrase() + '[\\S]*)(\\s|$)', word.regexOptions());
+          } else {
+            return new RegExp('\\b[\\w-]*' + word.processedPhrase() + '[\\w-]*\\b', word.regexOptions());
+          }
+        case 3: // Regular Expression (Advanced)
+          return new RegExp(word.value, word.regexOptions());
         case 0: // Exact: Word must match exactly (not sub-string)
+        default:
           // Filter Method: Remove
           // Match entire word that contains sub-string and surrounding whitespace
           // /\s?\bword\b\s?/gi
@@ -93,37 +124,6 @@ export default class Word {
             } else {
               return new RegExp('\\b' + word.processedPhrase() + '\\b', word.regexOptions());
             }
-          }
-        case 2: // Whole: Match entire word that contains sub-string
-          // /\b[\w-]*word[\w-]*\b/gi
-          if (word.unicode) {
-            // Work around for lack of word boundary support for unicode characters
-            // (^|[\s.,'"+!?|-]*)([\S]*куче[\S]*)([\s.,'"+!?|-]*|$)/giu
-            return new RegExp('(^|' + Word._unicodeWordBoundary + '*)([\\S]*' + word.processedPhrase() + '[\\S]*)(' + Word._unicodeWordBoundary + '*|$)', word.regexOptions());
-          } else if (word.hasEdgePunctuation()) { // Begin or end with punctuation (not \w))
-            return new RegExp('(^|\\s)([\\S]*' + word.processedPhrase() + '[\\S]*)(\\s|$)', word.regexOptions());
-          } else {
-            return new RegExp('\\b[\\w-]*' + word.processedPhrase() + '[\\w-]*\\b', word.regexOptions());
-          }
-        case 3: // Regular Expression (Advanced)
-          return new RegExp(word.value, word.regexOptions());
-        case 1: // Partial: Match any part of a word (sub-string)
-        default:
-          if (word._filterMethod === 2) { // Filter Method: Remove
-            // Match entire word that contains sub-string and surrounding whitespace
-            // /\s?\b[\w-]*word[\w-]*\b\s?/gi
-            if (word.unicode) {
-              // Work around for lack of word boundary support for unicode characters
-              // /(^|[\s.,'"+!?|-]?)[\w-]*(word)[\w-]*([\s.,'"+!?|-]?|$)/giu
-              return new RegExp('(^|' + Word._unicodeWordBoundary + '?)([\\w-]*' +  word.processedPhrase() + '[\\w-]*)(' + Word._unicodeWordBoundary + '?|$)', word.regexOptions());
-            } else if (word.hasEdgePunctuation()) { // Begin or end with punctuation (not \w))
-              return new RegExp('(^|\\s)([\\w-]*' +  word.processedPhrase() + '[\\w-]*)(\\s|$)', word.regexOptions());
-            } else {
-              return new RegExp('\\s?\\b[\\w-]*' +  word.processedPhrase() + '[\\w-]*\\b\\s?', word.regexOptions());
-            }
-          } else {
-            // /word/gi
-            return new RegExp(word.processedPhrase(), word.regexOptions());
           }
       }
     } catch(e) {

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -1,3 +1,4 @@
+import Constants from './lib/constants';
 import { dynamicList, escapeHTML, exportToFile, readFile, removeChildren, removeFromArray } from './lib/helper';
 import WebConfig from './webConfig';
 import Filter from './lib/filter';
@@ -177,11 +178,11 @@ export default class OptionPage {
     subInput.value = data.sub;
 
     let matchMethodSelect = document.createElement('select');
-    WebConfig._matchMethodNames.forEach((name, index) => {
+    Constants.orderedArray(Constants.MatchMethods).forEach((matchMethod, index) => {
       let optionElement = document.createElement('option');
-      optionElement.value = index.toString();
-      optionElement.classList.add(`bulkMatchMethod${index}`);
-      optionElement.textContent = name;
+      optionElement.value = Constants.MatchMethods[matchMethod].toString();
+      optionElement.classList.add(`bulkMatchMethod${Constants.MatchMethods[matchMethod]}`);
+      optionElement.textContent = matchMethod;
       matchMethodSelect.appendChild(optionElement);
     });
     matchMethodSelect.selectedIndex = data.matchMethod;
@@ -633,7 +634,7 @@ export default class OptionPage {
     this.updateFilterOptions();
 
     // Settings
-    let selectedFilter = document.getElementById(`filter${WebConfig._filterMethodNames[option.cfg.filterMethod]}`) as HTMLInputElement;
+    let selectedFilter = document.getElementById(`filter${Constants.filterMethodName(option.cfg.filterMethod)}`) as HTMLInputElement;
     let showCounter = document.getElementById('showCounter') as HTMLInputElement;
     let showSummary = document.getElementById('showSummary') as HTMLInputElement;
     let showUpdateNotification = document.getElementById('showUpdateNotification') as HTMLInputElement;
@@ -669,10 +670,11 @@ export default class OptionPage {
     let defaultWordSubstitution = document.getElementById('defaultWordSubstitutionText') as HTMLInputElement;
     defaultWordSubstitution.value = this.cfg.defaultSubstitution;
     removeChildren(defaultWordMatchMethodSelect);
-    for (let i = 0; i < WebConfig._matchMethodNames.slice(0,-1).length; i++) {
+    for (let i = 0; i < 3; i++) { // Skip Regex
       let optionElement = document.createElement('option');
-      optionElement.value = WebConfig._matchMethodNames[i].toString();
-      optionElement.textContent= WebConfig._matchMethodNames[i];
+      let matchMethodName = Constants.matchMethodName(i);
+      optionElement.value = matchMethodName;
+      optionElement.textContent = matchMethodName;
       defaultWordMatchMethodSelect.appendChild(optionElement);
     }
     defaultWordMatchMethodSelect.selectedIndex = this.cfg.defaultWordMatchMethod;
@@ -742,7 +744,7 @@ export default class OptionPage {
     if (word == '') { // New word
       wordText.value = '';
       OptionPage.disableBtn(wordRemove);
-      let selectedMatchMethod = document.getElementById(`wordMatch${WebConfig._matchMethodNames[option.cfg.defaultWordMatchMethod]}`) as HTMLInputElement;
+      let selectedMatchMethod = document.getElementById(`wordMatch${Constants.matchMethodName(option.cfg.defaultWordMatchMethod)}`) as HTMLInputElement;
       selectedMatchMethod.checked = true;
       wordMatchRepeated.checked = option.cfg.defaultWordRepeat;
       wordMatchSeparators.checked = option.cfg.defaultWordSeparators;
@@ -760,7 +762,7 @@ export default class OptionPage {
       OptionPage.enableBtn(wordRemove);
       let wordCfg = option.cfg.words[word];
       wordText.value = word;
-      let selectedMatchMethod = document.getElementById(`wordMatch${WebConfig._matchMethodNames[wordCfg.matchMethod]}`) as HTMLInputElement;
+      let selectedMatchMethod = document.getElementById(`wordMatch${Constants.matchMethodName(wordCfg.matchMethod)}`) as HTMLInputElement;
       selectedMatchMethod.checked = true;
       wordMatchRepeated.checked = wordCfg.repeat;
       wordMatchSeparators.checked = wordCfg.separators === undefined ? option.cfg.defaultWordSeparators : wordCfg.separators;
@@ -832,7 +834,7 @@ export default class OptionPage {
     words.forEach(word => {
       let filteredWord = word;
       if (word != words[0] && wordlistFilter.cfg.filterWordList) {
-        if (wordlistFilter.cfg.words[word].matchMethod === 3) { // Regexp
+        if (wordlistFilter.cfg.words[word].matchMethod === Constants.MatchMethods.Regex) { // Regexp
           filteredWord = wordlistFilter.cfg.words[word].sub || wordlistFilter.cfg.defaultSubstitution;
         } else {
           filteredWord = wordlistFilter.replaceText(word, 0, false); // Using 0 (All) here to filter all words
@@ -1172,7 +1174,7 @@ export default class OptionPage {
 
       let wordOptions: WordOptions = {
         lists: lists,
-        matchMethod: WebConfig._matchMethodNames.indexOf(selectedMatchMethod.value),
+        matchMethod: Constants.MatchMethods[selectedMatchMethod.value],
         repeat: wordMatchRepeated.checked,
         separators: wordMatchSeparators.checked,
         sub: sub
@@ -1214,7 +1216,7 @@ export default class OptionPage {
   }
 
   async selectFilterMethod(evt) {
-    option.cfg.filterMethod = WebConfig._filterMethodNames.indexOf(evt.target.value);
+    option.cfg.filterMethod = Constants.FilterMethods[evt.target.value];
     if (await option.saveProp('filterMethod')) {
       filter.rebuildWordlists();
       this.populateOptions();
@@ -1329,17 +1331,17 @@ export default class OptionPage {
   updateFilterOptions() {
     // Show/hide options as needed
     switch(this.cfg.filterMethod) {
-      case 0: // Censor
+      case Constants.FilterMethods.Censor:
         OptionPage.show(document.getElementById('censorSettings'));
         OptionPage.hide(document.getElementById('substitutionSettings'));
         OptionPage.hide(document.getElementById('wordSubstitution'));
         break;
-      case 1: // Substitution
+      case Constants.FilterMethods.Substitute:
         OptionPage.hide(document.getElementById('censorSettings'));
         OptionPage.show(document.getElementById('substitutionSettings'));
         OptionPage.show(document.getElementById('wordSubstitution'));
         break;
-      case 2: // Remove
+      case Constants.FilterMethods.Remove:
         OptionPage.hide(document.getElementById('censorSettings'));
         OptionPage.hide(document.getElementById('substitutionSettings'));
         OptionPage.hide(document.getElementById('wordSubstitution'));

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -832,7 +832,7 @@ export default class OptionPage {
     words.forEach(word => {
       let filteredWord = word;
       if (word != words[0] && wordlistFilter.cfg.filterWordList) {
-        if (wordlistFilter.cfg.words[word].matchMethod == 4) { // Regexp
+        if (wordlistFilter.cfg.words[word].matchMethod === 3) { // Regexp
           filteredWord = wordlistFilter.cfg.words[word].sub || wordlistFilter.cfg.defaultSubstitution;
         } else {
           filteredWord = wordlistFilter.replaceText(word, 0, false); // Using 0 (All) here to filter all words

--- a/src/script/popup.ts
+++ b/src/script/popup.ts
@@ -1,3 +1,4 @@
+import Constants from './lib/constants';
 import { dynamicList, escapeHTML } from './lib/helper';
 import WebAudioSites from './webAudioSites';
 import WebConfig from './webConfig';
@@ -83,7 +84,7 @@ class Popup {
     let wordListContainer = document.getElementById('wordListContainer') as HTMLInputElement;
     let wordlistSelect = document.getElementById('wordlistSelect') as HTMLSelectElement;
     let audioWordlistSelect = document.getElementById('audioWordlistSelect') as HTMLSelectElement;
-    dynamicList(WebConfig._filterMethodNames, filterMethodSelect);
+    dynamicList(Constants.orderedArray(Constants.FilterMethods), filterMethodSelect);
     filterMethodSelect.selectedIndex = popup.cfg.filterMethod;
 
     if (popup.cfg.wordlistsEnabled) {

--- a/src/script/webAudioSites.ts
+++ b/src/script/webAudioSites.ts
@@ -1,3 +1,5 @@
+import Constants from './lib/constants';
+
 export default class WebAudioSites {
   static combineSites(sites: { [site: string]: AudioRules[] } = {}): { [site: string]: AudioRules[] } {
     return Object.assign({}, WebAudioSites.sites, sites);
@@ -10,7 +12,7 @@ export default class WebAudioSites {
         mode: 'watcher',
         iframe: false,
         parentSelector: 'div.webPlayerContainer div p > span',
-        showSubtitles: 0,
+        showSubtitles: Constants.ShowSubtitles.All,
         simpleUnmute: true,
         subtitleSelector: 'div.webPlayerContainer div span > span',
         videoSelector: 'div.webPlayerElement video[src]'

--- a/src/script/webConfig.ts
+++ b/src/script/webConfig.ts
@@ -1,3 +1,4 @@
+import Constants from './lib/constants';
 import Config from './lib/config';
 
 export default class WebConfig extends Config {
@@ -24,9 +25,9 @@ export default class WebConfig extends Config {
     muteAudio: false,
     muteAudioOnly: false,
     muteCueRequireShowing: true,
-    muteMethod: 0, // 0: Mute Tab, 1: Video Volume
+    muteMethod: Constants.MuteMethods.Tab,
     password: null,
-    showSubtitles: 0,
+    showSubtitles: Constants.ShowSubtitles.All,
     showUpdateNotification: true,
     youTubeAutoSubsMax: 0,
     youTubeAutoSubsMin: 0,

--- a/src/script/webFilter.ts
+++ b/src/script/webFilter.ts
@@ -238,7 +238,7 @@ export default class WebFilter extends Filter {
         this.summary[word].count += 1;
       } else {
         let result;
-        if (this.cfg.words[word].matchMethod == 4) { // Regexp
+        if (this.cfg.words[word].matchMethod === 3) { // Regexp
           result = this.cfg.words[word].sub || this.cfg.defaultSubstitution;
         } else {
           result = filter.replaceText(word, 0, false); // We can use 0 (All) here because we are just filtering a word

--- a/src/script/webFilter.ts
+++ b/src/script/webFilter.ts
@@ -1,3 +1,4 @@
+import Constants from './lib/constants';
 import Domain from './domain';
 import Filter from './lib/filter';
 import Page from './page';
@@ -238,7 +239,7 @@ export default class WebFilter extends Filter {
         this.summary[word.value].count += 1;
       } else {
         let result;
-        if (word.matchMethod === 3) { // Regexp
+        if (word.matchMethod === Constants.MatchMethods.Regex) {
           result = word.sub || this.cfg.defaultSubstitution;
         } else {
           result = filter.replaceText(word.value, 0, false); // We can use 0 (All) here because we are just filtering a word
@@ -268,7 +269,7 @@ export default class WebFilter extends Filter {
 
   sendInitState(message: Message) {
     // Reset muted state on page load if we muted the tab audio
-    if (this.cfg.muteAudio && this.cfg.muteMethod == 0) { message.clearMute = true; }
+    if (this.cfg.muteAudio && this.cfg.muteMethod == Constants.MuteMethods.Tab) { message.clearMute = true; }
 
     // Send page state to color icon badge
     if (!this.iframe) { message.setBadgeColor = true; }

--- a/src/script/webFilter.ts
+++ b/src/script/webFilter.ts
@@ -234,17 +234,17 @@ export default class WebFilter extends Filter {
   foundMatch(word) {
     super.foundMatch(word);
     if (this.cfg.showSummary) {
-      if (this.summary[word]) {
-        this.summary[word].count += 1;
+      if (this.summary[word.value]) {
+        this.summary[word.value].count += 1;
       } else {
         let result;
-        if (this.cfg.words[word].matchMethod === 3) { // Regexp
-          result = this.cfg.words[word].sub || this.cfg.defaultSubstitution;
+        if (word.matchMethod === 3) { // Regexp
+          result = word.sub || this.cfg.defaultSubstitution;
         } else {
-          result = filter.replaceText(word, 0, false); // We can use 0 (All) here because we are just filtering a word
+          result = filter.replaceText(word.value, 0, false); // We can use 0 (All) here because we are just filtering a word
         }
 
-        this.summary[word] = { filtered: result, count: 1 };
+        this.summary[word.value] = { filtered: result, count: 1 };
       }
     }
   }

--- a/src/static/optionPage.html
+++ b/src/static/optionPage.html
@@ -192,7 +192,7 @@
 
       <br>
       <label>
-        <input id="wordMatchRegular-Expression" type="radio" class="w3-radio" name="wordMatchMethod" value="Regular-Expression">
+        <input id="wordMatchRegex" type="radio" class="w3-radio" name="wordMatchMethod" value="Regex">
         Regex
       </label>
     </div>

--- a/test/dataMigration.spec.js
+++ b/test/dataMigration.spec.js
@@ -1,4 +1,5 @@
 const expect = require('chai').expect;
+import Constants from './built/lib/constants';
 import DataMigration from './built/dataMigration';
 import WebConfig from './built/webConfig';
 
@@ -7,9 +8,9 @@ describe('DataMigration', function() {
     it('should add wordlist to all words', function() {
       let cfg = {
         words: {
-          'test': { matchMethod: 0, repeat: true, separators: false, sub: 'tset' },
-          'another': { matchMethod: 0, repeat: true, separators: false, sub: 'tset' },
-          'testWithList': { lists: [1,3,5], matchMethod: 0, repeat: true, separators: false, sub: 'tset' },
+          'test': { matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'tset' },
+          'another': { matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'tset' },
+          'testWithList': { lists: [1,3,5], matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'tset' },
         }
       };
       let dataMigration = new DataMigration(cfg);
@@ -24,9 +25,9 @@ describe('DataMigration', function() {
     it('should remove global match method and adjust RegExp method', function() {
       let data = {
         words: {
-          'test': { matchMethod: 0, repeat: true, separators: false, sub: 'tset' },
-          'another': { matchMethod: 1, repeat: true, separators: false, sub: 'tset' },
-          'testWithList': { lists: [1,3,5], matchMethod: 0, repeat: true, separators: false, sub: 'tset' },
+          'test': { matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'tset' },
+          'another': { matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: false, sub: 'tset' },
+          'testWithList': { lists: [1,3,5], matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'tset' },
           '^myRegexp$': { lists: [1,3,5], matchMethod: 4, repeat: true, separators: false, sub: 'tset' },
         },
         globalMatchMethod: 3,
@@ -35,10 +36,10 @@ describe('DataMigration', function() {
       cfg.remove = (prop) => { delete cfg[prop]; return true; }; // TODO: Find a good way to mock chrome.*
       let dataMigration = new DataMigration(cfg);
       dataMigration.removeGlobalMatchMethod();
-      expect(cfg.words['test'].matchMethod).to.eql(0);
-      expect(cfg.words['another'].matchMethod).to.eql(1);
-      expect(cfg.words['testWithList'].matchMethod).to.eql(0);
-      expect(cfg.words['^myRegexp$'].matchMethod).to.eql(3);
+      expect(cfg.words['test'].matchMethod).to.eql(Constants.MatchMethods.Exact);
+      expect(cfg.words['another'].matchMethod).to.eql(Constants.MatchMethods.Partial);
+      expect(cfg.words['testWithList'].matchMethod).to.eql(Constants.MatchMethods.Exact);
+      expect(cfg.words['^myRegexp$'].matchMethod).to.eql(Constants.MatchMethods.Regex);
       expect(cfg.globalMatchMethod).to.not.exist;
     });
   });

--- a/test/lib/config.spec.js
+++ b/test/lib/config.spec.js
@@ -1,4 +1,5 @@
 const expect = require('chai').expect;
+import Constants from '../built/lib/constants';
 import Config from '../built/lib/config';
 
 describe('Config', function() {
@@ -31,7 +32,7 @@ describe('Config', function() {
     });
 
     it('should add a new word to the config with provided options', function() {
-      let wordOptions = { matchMethod: 1, repeat: true, sub: 'Older-word' };
+      let wordOptions = { matchMethod: Constants.MatchMethods.Partial , repeat: true, sub: 'Older-word' };
       expect(config.addWord('newer-word', wordOptions)).to.equal(true);
       expect(Object.keys(config.words)).to.include('newer-word');
       expect(config.words['newer-word'].matchMethod).to.equal(wordOptions.matchMethod);

--- a/test/lib/filter.spec.js
+++ b/test/lib/filter.spec.js
@@ -27,7 +27,7 @@ describe('Filter', () => {
       filter.cfg = new Config({ words: testWords, filterMethod: 0 });
       filter.cfg = new Config({
         filterMethod: 0,
-        words: Object.assign(testWords, { '^regexp.*?$': { matchMethod: 3, repeat: false, words: ['substitute'] } })
+        words: Object.assign(testWords, { '^regexp.*?$': { matchMethod: 3, repeat: false, sub: 'substitute' } })
       });
       filter.init();
       expect(filter.wordlists[filter.wordlistId].regExps).to.eql([
@@ -113,10 +113,10 @@ describe('Filter', () => {
         });
       });
 
-      it('Should filter an RegExp and fixed length (5) with preserveLast', () => {
+      it('Should filter a RegExp and fixed length (5) with preserveLast', () => {
         let filter = new Filter;
         filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0, censorCharacter: '_', censorFixedLength: 5, preserveFirst: false, preserveLast: true });
-        filter.cfg.words['^The'] = { matchMethod: 3, repeat: false, words: ['substitute'] };
+        filter.cfg.words['^The'] = { matchMethod: 3, repeat: false, sub: 'substitute' };
         filter.init();
         expect(filter.replaceText('The best things are always the best.')).to.equal('____e best things are always the best.');
       });
@@ -166,7 +166,7 @@ describe('Filter', () => {
         it('preserveFirst', () => {
           let filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: false });
-          filter.cfg.words['врата'] = { matchMethod: 0, repeat: true, words: ['door'] };
+          filter.cfg.words['врата'] = { matchMethod: 0, repeat: true, sub: 'door' };
           filter.init();
           expect(filter.replaceText('this even works on unicode words like врата, cool huh?')).to.equal('this even works on unicode w**** like в****, cool huh?');
         });
@@ -174,7 +174,7 @@ describe('Filter', () => {
         it('preserveFirst and preserveLast', () => {
           let filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: true });
-          filter.cfg.words['котка'] = { matchMethod: 1, repeat: true, words: ['cat'] };
+          filter.cfg.words['котка'] = { matchMethod: 1, repeat: true, sub: 'cat' };
           filter.init();
           expect(filter.replaceText('The коткаs in the hat')).to.equal('The к***аs in the hat');
         });
@@ -182,7 +182,7 @@ describe('Filter', () => {
         it('With (_) characters and preserveFirst', () => {
           let filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0, censorCharacter: '_', censorFixedLength: 0, preserveFirst: true, preserveLast: false });
-          filter.cfg.words['куче'] = { matchMethod: 2, repeat: true, words: ['dog'] };
+          filter.cfg.words['куче'] = { matchMethod: 2, repeat: true, sub: 'dog' };
           filter.init();
           expect(filter.replaceText('The bigкучеs ran around the yard.')).to.equal('The b_______ ran around the yard.');
         });
@@ -381,7 +381,7 @@ describe('Filter', () => {
       it('Should filter a RegExp', () => {
         let filter = new Filter;
         filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 2 });
-        filter.cfg.words['this and everything after.*$'] = { matchMethod: 3, repeat: false, words: ['substitute'] };
+        filter.cfg.words['this and everything after.*$'] = { matchMethod: 3, repeat: false, sub: 'substitute' };
         filter.init();
         expect(filter.replaceText('Have you ever done this and everything after it?')).to.equal('Have you ever done ');
       });
@@ -419,7 +419,7 @@ describe('Filter', () => {
         it('Exact word', () => {
           let filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 2 });
-          filter.cfg.words['врата'] = { matchMethod: 0, repeat: true, words: ['door'] };
+          filter.cfg.words['врата'] = { matchMethod: 0, repeat: true, sub: 'door' };
           filter.init();
           expect(filter.replaceText('This even works on врата. cool huh?')).to.equal('This even works on. cool huh?');
           expect(filter.replaceText('This even works on врата, cool huh?')).to.equal('This even works on, cool huh?');
@@ -429,7 +429,7 @@ describe('Filter', () => {
         it('Partial word', () => {
           let filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 2 });
-          filter.cfg.words['врата'] = { matchMethod: 1, repeat: true, words: ['door'] };
+          filter.cfg.words['врата'] = { matchMethod: 1, repeat: true, sub: 'door' };
           filter.init();
           expect(filter.replaceText('This even works on with-врата. Cool huh?')).to.equal('This even works on. Cool huh?');
           expect(filter.replaceText('The вратаs in the hat')).to.equal('The in the hat');

--- a/test/lib/filter.spec.js
+++ b/test/lib/filter.spec.js
@@ -27,7 +27,7 @@ describe('Filter', () => {
       filter.cfg = new Config({ words: testWords, filterMethod: 0 });
       filter.cfg = new Config({
         filterMethod: 0,
-        words: Object.assign(testWords, { '^regexp.*?$': { matchMethod: 4, repeat: false, words: ['substitute'] } })
+        words: Object.assign(testWords, { '^regexp.*?$': { matchMethod: 3, repeat: false, words: ['substitute'] } })
       });
       filter.init();
       expect(filter.wordlists[filter.wordlistId].regExps).to.eql([
@@ -116,7 +116,7 @@ describe('Filter', () => {
       it('Should filter an RegExp and fixed length (5) with preserveLast', () => {
         let filter = new Filter;
         filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0, censorCharacter: '_', censorFixedLength: 5, preserveFirst: false, preserveLast: true });
-        filter.cfg.words['^The'] = { matchMethod: 4, repeat: false, words: ['substitute'] };
+        filter.cfg.words['^The'] = { matchMethod: 3, repeat: false, words: ['substitute'] };
         filter.init();
         expect(filter.replaceText('The best things are always the best.')).to.equal('____e best things are always the best.');
       });
@@ -381,7 +381,7 @@ describe('Filter', () => {
       it('Should filter a RegExp', () => {
         let filter = new Filter;
         filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 2 });
-        filter.cfg.words['this and everything after.*$'] = { matchMethod: 4, repeat: false, words: ['substitute'] };
+        filter.cfg.words['this and everything after.*$'] = { matchMethod: 3, repeat: false, words: ['substitute'] };
         filter.init();
         expect(filter.replaceText('Have you ever done this and everything after it?')).to.equal('Have you ever done ');
       });

--- a/test/lib/filter.spec.js
+++ b/test/lib/filter.spec.js
@@ -1,12 +1,13 @@
 const expect = require('chai').expect;
+import Constants from '../built/lib/constants';
 import Config from '../built/lib/config';
 import Filter from '../built/lib/filter';
 
 const testWords = {
-  'example': { matchMethod: 0, repeat: true, sub: 'demo', lists: [] },
-  'placeholder': { matchMethod: 0, repeat: false, sub: 'variable', lists: [] },
-  'sample': { matchMethod: 1, repeat: false, sub: 'piece', lists: [] },
-  'word': { matchMethod: 2, repeat: true, sub: 'idea', lists: [] }
+  'example': { matchMethod: Constants.MatchMethods.Exact, repeat: true, sub: 'demo', lists: [] },
+  'placeholder': { matchMethod: Constants.MatchMethods.Exact, repeat: false, sub: 'variable', lists: [] },
+  'sample': { matchMethod: Constants.MatchMethods.Partial, repeat: false, sub: 'piece', lists: [] },
+  'word': { matchMethod: Constants.MatchMethods.Whole, repeat: true, sub: 'idea', lists: [] }
 };
 
 describe('Filter', () => {
@@ -24,10 +25,10 @@ describe('Filter', () => {
   describe('init()', () => {
     it('should return RegExp list and be idempotent', () => {
       let filter = new Filter;
-      filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0 });
+      filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Censor });
       filter.cfg = new Config({
-        filterMethod: 0,
-        words: Object.assign({}, testWords, { '^regexp.*?$': { matchMethod: 3, repeat: false, sub: 'substitute' } })
+        filterMethod: Constants.FilterMethods.Censor,
+        words: Object.assign({}, testWords, { '^regexp.*?$': { matchMethod: Constants.MatchMethods.Regex, repeat: false, sub: 'substitute' } })
       });
       filter.init();
       expect(filter.wordlists[filter.wordlistId].regExps).to.eql([
@@ -49,7 +50,7 @@ describe('Filter', () => {
 
     it('should default to wordlist 0 when none configured', () => {
       let filter = new Filter;
-      filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0 });
+      filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Censor });
       filter.wordlistId = undefined;
       expect(filter.wordlistId).to.be.undefined;
       filter.cfg.wordlistId = undefined;
@@ -63,13 +64,13 @@ describe('Filter', () => {
     it('should rebuild all wordlists', () => {
       let filter = new Filter;
       filter.cfg = new Config({ words: Object.assign({}, testWords) });
-      filter.cfg.words['book'] = { matchMethod: 2, repeat: true, sub: 'journal', lists: [1] };
+      filter.cfg.words['book'] = { matchMethod: Constants.MatchMethods.Whole, repeat: true, sub: 'journal', lists: [1] };
       filter.init();
       expect(Object.keys(filter.wordlists).length).to.equal(1);
       filter.buildWordlist(1);
       expect(Object.keys(filter.wordlists).length).to.equal(2);
       expect(Object.keys(filter.wordlists[1].all).length).to.equal(1);
-      filter.cfg.words['food'] = { matchMethod: 2, repeat: true, sub: 'sustenance', lists: [1] };
+      filter.cfg.words['food'] = { matchMethod: Constants.MatchMethods.Whole, repeat: true, sub: 'sustenance', lists: [1] };
       expect(Object.keys(filter.wordlists[0].all).length).to.equal(5);
       expect(Object.keys(filter.wordlists[1].all).length).to.equal(1);
       filter.rebuildWordlists();
@@ -84,14 +85,14 @@ describe('Filter', () => {
       describe('Exact', () => {
         it('preserveFirst', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: false });
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Censor, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: false });
           filter.init();
           expect(filter.replaceText('this is a placeholder placeholder.')).to.equal('this is a p********** p**********.');
         });
 
         it('With (-) characters and no preserveFirst or preserveLast', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0, censorCharacter: '-', censorFixedLength: 0, preserveFirst: false, preserveLast: false });
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Censor, censorCharacter: '-', censorFixedLength: 0, preserveFirst: false, preserveLast: false });
           filter.init();
           expect(filter.replaceText('A cool example sentence.')).to.equal('A cool ------- sentence.');
         });
@@ -100,7 +101,7 @@ describe('Filter', () => {
       describe('Partial', () => {
         it('With preserveFirst and preserveLast and update stats', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: true });
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Censor, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: true });
           filter.init();
           expect(filter.counter).to.equal(0);
           expect(filter.replaceText('this sample is a pretty good sampler to sample.')).to.equal('this s****e is a pretty good s****er to s****e.');
@@ -109,8 +110,8 @@ describe('Filter', () => {
 
         it('With separators', () => {
           let filter = new Filter;
-          let words = { pizza: { matchMethod: 1, repeat: true, separators: true } };
-          filter.cfg = new Config({ words: words, filterMethod: 0, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: true });
+          let words = { pizza: { matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: true } };
+          filter.cfg = new Config({ words: words, filterMethod: Constants.FilterMethods.Censor, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: true });
           filter.init();
           expect(filter.replaceText('I love to eat P-I-Z-___Z---A!')).to.equal('I love to eat P************A!');
           expect(filter.replaceText('I love to eat P-I-Z-   Z---A!')).to.equal('I love to eat P************A!');
@@ -118,7 +119,7 @@ describe('Filter', () => {
 
         it('Ending with punctuation', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: { 'this!': { matchMethod: 1 } }, filterMethod: 0, censorCharacter: '_', preserveFirst: false });
+          filter.cfg = new Config({ words: { 'this!': { matchMethod: Constants.MatchMethods.Partial } }, filterMethod: Constants.FilterMethods.Censor, censorCharacter: '_', preserveFirst: false });
           filter.init();
           expect(filter.replaceText('I love allthis! Do you?')).to.equal('I love all_____ Do you?');
           expect(filter.replaceText('I love this! Do you?')).to.equal('I love _____ Do you?');
@@ -128,7 +129,7 @@ describe('Filter', () => {
       describe('Whole', () => {
         it('With (_) characters and fixed length (3) and not update stats', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0, censorCharacter: '_', censorFixedLength: 3, preserveFirst: false, preserveLast: false });
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Censor, censorCharacter: '_', censorFixedLength: 3, preserveFirst: false, preserveLast: false });
           filter.init();
           expect(filter.counter).to.equal(0);
           expect(filter.replaceText('Words used to be okay, but now even a word is bad.', filter.wordlistId, false)).to.equal('___ used to be okay, but now even a ___ is bad.');
@@ -137,7 +138,7 @@ describe('Filter', () => {
 
         it('Ending with punctuation', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: { 'this!': { matchMethod: 2 } }, filterMethod: 0, censorCharacter: '_', preserveFirst: false });
+          filter.cfg = new Config({ words: { 'this!': { matchMethod: Constants.MatchMethods.Whole } }, filterMethod: Constants.FilterMethods.Censor, censorCharacter: '_', preserveFirst: false });
           filter.init();
           expect(filter.replaceText('I love allthis! Do you?')).to.equal('I love ________ Do you?');
           expect(filter.replaceText('I love this! Do you?')).to.equal('I love _____ Do you?');
@@ -147,8 +148,8 @@ describe('Filter', () => {
       describe('RegExp', () => {
         it('Should filter a RegExp and fixed length (5) with preserveLast', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0, censorCharacter: '_', censorFixedLength: 5, preserveFirst: false, preserveLast: true });
-          filter.cfg.words['^The'] = { matchMethod: 3, repeat: false, sub: 'substitute' };
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Censor, censorCharacter: '_', censorFixedLength: 5, preserveFirst: false, preserveLast: true });
+          filter.cfg.words['^The'] = { matchMethod: Constants.MatchMethods.Regex, repeat: false, sub: 'substitute' };
           filter.init();
           expect(filter.replaceText('The best things are always the best.')).to.equal('____e best things are always the best.');
         });
@@ -157,8 +158,8 @@ describe('Filter', () => {
       describe('whitelist', () => {
         it('case-sensitive exact match', () => {
           let filter = new Filter;
-          let words = { master: { matchMethod: 1, repeat: true, sub: 'padawan' } };
-          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: 0, wordWhitelist: ['Master'] });
+          let words = { master: { matchMethod: Constants.MatchMethods.Partial, repeat: true, sub: 'padawan' } };
+          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FilterMethods.Censor, wordWhitelist: ['Master'] });
           filter.init();
           expect(filter.replaceText('Can the master outsmart the Master?')).to.equal('Can the m***** outsmart the Master?');
           expect(filter.counter).to.equal(1);
@@ -166,8 +167,8 @@ describe('Filter', () => {
 
         it('case-sensitive partial match', () => {
           let filter = new Filter;
-          let words = { more: { matchMethod: 1, repeat: true } };
-          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: 0, wordWhitelist: ['smore'] });
+          let words = { more: { matchMethod: Constants.MatchMethods.Partial, repeat: true } };
+          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FilterMethods.Censor, wordWhitelist: ['smore'] });
           filter.init();
           expect(filter.replaceText('Would you like smore smores?')).to.equal('Would you like smore sm***s?');
           expect(filter.counter).to.equal(1);
@@ -176,10 +177,10 @@ describe('Filter', () => {
         it('case-insensitive exact match', () => {
           let filter = new Filter;
           let words = {
-            master: { matchMethod: 1, repeat: true, sub: 'padawan' },
-            the: { matchMethod: 1, repeat: true, sub: 'teh' }
+            master: { matchMethod: Constants.MatchMethods.Partial, repeat: true, sub: 'padawan' },
+            the: { matchMethod: Constants.MatchMethods.Partial, repeat: true, sub: 'teh' }
           };
-          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: 0, iWordWhitelist: ['master'] });
+          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FilterMethods.Censor, iWordWhitelist: ['master'] });
           filter.init();
           expect(filter.replaceText('Can the master outsmart the Master?')).to.equal('Can t** master outsmart t** Master?');
           expect(filter.counter).to.equal(2);
@@ -187,8 +188,8 @@ describe('Filter', () => {
 
         it('case-sinsensitive partial match', () => {
           let filter = new Filter;
-          let words = { more: { matchMethod: 1, repeat: true } };
-          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: 0, iWordWhitelist: ['smore'] });
+          let words = { more: { matchMethod: Constants.MatchMethods.Partial, repeat: true } };
+          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FilterMethods.Censor, iWordWhitelist: ['smore'] });
           filter.init();
           expect(filter.replaceText('Would you like sMorE smores?')).to.equal('Would you like sMorE sm***s?');
           expect(filter.counter).to.equal(1);
@@ -198,40 +199,40 @@ describe('Filter', () => {
       describe('Unicode characters', () => {
         it('preserveFirst', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: false });
-          filter.cfg.words['врата'] = { matchMethod: 0, repeat: true, sub: 'door' };
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Censor, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: false });
+          filter.cfg.words['врата'] = { matchMethod: Constants.MatchMethods.Exact, repeat: true, sub: 'door' };
           filter.init();
           expect(filter.replaceText('this even works on unicode words like врата, cool huh?')).to.equal('this even works on unicode w**** like в****, cool huh?');
         });
 
         it('preserveFirst and preserveLast', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: true });
-          filter.cfg.words['котка'] = { matchMethod: 1, repeat: true, sub: 'cat' };
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Censor, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: true });
+          filter.cfg.words['котка'] = { matchMethod: Constants.MatchMethods.Partial, repeat: true, sub: 'cat' };
           filter.init();
           expect(filter.replaceText('The коткаs in the hat')).to.equal('The к***аs in the hat');
         });
 
         it('With (_) characters and preserveFirst', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0, censorCharacter: '_', censorFixedLength: 0, preserveFirst: true, preserveLast: false });
-          filter.cfg.words['куче'] = { matchMethod: 2, repeat: true, sub: 'dog' };
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Censor, censorCharacter: '_', censorFixedLength: 0, preserveFirst: true, preserveLast: false });
+          filter.cfg.words['куче'] = { matchMethod: Constants.MatchMethods.Whole, repeat: true, sub: 'dog' };
           filter.init();
           expect(filter.replaceText('The bigкучеs ran around the yard.')).to.equal('The b_______ ran around the yard.');
         });
 
         it('With (*) characters', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0, censorCharacter: '*', censorFixedLength: 0, preserveFirst: false, preserveLast: false });
-          filter.cfg.words['словен'] = { matchMethod: 2, repeat: false };
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Censor, censorCharacter: '*', censorFixedLength: 0, preserveFirst: false, preserveLast: false });
+          filter.cfg.words['словен'] = { matchMethod: Constants.MatchMethods.Whole, repeat: false };
           filter.init();
           expect(filter.replaceText('За пределами Словении этнические словенцы компактно')).to.equal('За пределами ******** этнические ******** компактно');
         });
 
         it('Should not filter a whitelisted word (partial match)', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 0, censorCharacter: '*', preserveFirst: false, preserveLast: false, wordWhitelist: ['словенцы'] });
-          filter.cfg.words['ловен'] = { matchMethod: 1, repeat: false };
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Censor, censorCharacter: '*', preserveFirst: false, preserveLast: false, wordWhitelist: ['словенцы'] });
+          filter.cfg.words['ловен'] = { matchMethod: Constants.MatchMethods.Partial, repeat: false };
           filter.init();
           expect(filter.replaceText('За пределами Словении этнические словенцы компактно')).to.equal('За пределами С*****ии этнические словенцы компактно');
           expect(filter.counter).to.equal(1);
@@ -243,14 +244,14 @@ describe('Filter', () => {
       describe('Exact', () => {
         it('Marked and preserveCase', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 1, substitutionMark: true, preserveCase: true });
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Substitute, substitutionMark: true, preserveCase: true });
           filter.init();
           expect(filter.replaceText('I love having good examples as an Example.')).to.equal('I love having good examples as an [Demo].');
         });
 
         it('Marked and preserveCase with repeated characters', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 1, substitutionMark: true, preserveCase: true });
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Substitute, substitutionMark: true, preserveCase: true });
           filter.init();
           expect(filter.replaceText('I love having good examples as an Exxaammppllee.')).to.equal('I love having good examples as an [Demo].');
         });
@@ -258,13 +259,13 @@ describe('Filter', () => {
         it('Ending with punctuation', () => {
           let filter = new Filter;
           filter.cfg = new Config({
-            filterMethod: 1,
+            filterMethod: Constants.FilterMethods.Substitute,
             substitutionMark: false,
             preserveCase: true,
             words: {
-              'this!': { matchMethod: 0, repeat: false, sub: 'that!' },
-              '!bang': { matchMethod: 0, repeat: true, sub: '!poof' },
-              '!another!': { matchMethod: 0, repeat: false, sub: '$znother#' }
+              'this!': { matchMethod: Constants.MatchMethods.Exact, repeat: false, sub: 'that!' },
+              '!bang': { matchMethod: Constants.MatchMethods.Exact, repeat: true, sub: '!poof' },
+              '!another!': { matchMethod: Constants.MatchMethods.Exact, repeat: false, sub: '$znother#' }
             },
           });
           filter.init();
@@ -279,22 +280,22 @@ describe('Filter', () => {
       describe('Partial', () => {
         it('Not marked and preserveCase', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 1, substitutionMark: false, preserveCase: true });
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Substitute, substitutionMark: false, preserveCase: true });
           filter.init();
           expect(filter.replaceText('This Sample is a pretty good sampler to sample.')).to.equal('This Piece is a pretty good piecer to piece.');
         });
 
         it('Default substitution not marked and preserveCase', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), defaultSubstitution: 'censored', filterMethod: 1, substitutionMark: false, preserveCase: true });
-          filter.cfg.words['this'] = { matchMethod: 0, repeat: true, sub: '' };
+          filter.cfg = new Config({ words: Object.assign({}, testWords), defaultSubstitution: 'censored', filterMethod: Constants.FilterMethods.Substitute, substitutionMark: false, preserveCase: true });
+          filter.cfg.words['this'] = { matchMethod: Constants.MatchMethods.Exact, repeat: true, sub: '' };
           filter.init();
           expect(filter.replaceText('This Sample is a pretty good sampler to sample.')).to.equal('Censored Piece is a pretty good piecer to piece.');
         });
 
         it('Not marked, not repeated, and preserveCase and update stats', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 1, substitutionMark: false, preserveCase: true });
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Substitute, substitutionMark: false, preserveCase: true });
           filter.init();
           expect(filter.counter).to.equal(0);
           expect(filter.replaceText('This Sample is a pretty good sampler to saammppllee.')).to.equal('This Piece is a pretty good piecer to saammppllee.');
@@ -303,7 +304,7 @@ describe('Filter', () => {
 
         it('Marked and not preserveCase and not update stats', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 1, substitutionMark: true, preserveCase: false });
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Substitute, substitutionMark: true, preserveCase: false });
           filter.init();
           expect(filter.counter).to.equal(0);
           expect(filter.replaceText('This Sample is a pretty good sampler to sample.', filter.wordlistId, false)).to.equal('This [piece] is a pretty good [piece]r to [piece].');
@@ -312,8 +313,8 @@ describe('Filter', () => {
 
         it('Match separators', () => {
           let filter = new Filter;
-          let words = { pizza: { matchMethod: 1, repeat: true, separators: true, sub: 'pie' } };
-          filter.cfg = new Config({ words: words, filterMethod: 1, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: true });
+          let words = { pizza: { matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: true, sub: 'pie' } };
+          filter.cfg = new Config({ words: words, filterMethod: Constants.FilterMethods.Substitute, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: true });
           filter.init();
           expect(filter.replaceText('I love to eat P-I-Z-Z-A!')).to.equal('I love to eat PIE!');
           expect(filter.replaceText('I love to eat P-I-Z-___Z---A!')).to.equal('I love to eat PIE!');
@@ -324,8 +325,8 @@ describe('Filter', () => {
       describe('RegExp', () => {
         it('Should filter a RegExp with capture groups', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 1 });
-          filter.cfg.words['c(a|u)t'] = { matchMethod: 3, repeat: false, sub: 'bit' };
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Substitute });
+          filter.cfg.words['c(a|u)t'] = { matchMethod: Constants.MatchMethods.Regex, repeat: false, sub: 'bit' };
           filter.init();
           expect(filter.replaceText('Have you ever been cut by a Cat?')).to.equal('Have you ever been bit by a Bit?');
         });
@@ -334,8 +335,8 @@ describe('Filter', () => {
       describe('whitelist', () => {
         it('case-sensitive exact match', () => {
           let filter = new Filter;
-          let words = { master: { matchMethod: 2, repeat: true, sub: 'padawan' } };
-          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: 1, substitutionMark: false, preserveCase: true, wordWhitelist: ['Master'] });
+          let words = { master: { matchMethod: Constants.MatchMethods.Whole, repeat: true, sub: 'padawan' } };
+          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FilterMethods.Substitute, substitutionMark: false, preserveCase: true, wordWhitelist: ['Master'] });
           filter.init();
           expect(filter.replaceText('Can the master outsmart the Master?')).to.equal('Can the padawan outsmart the Master?');
           expect(filter.counter).to.equal(1);
@@ -344,10 +345,10 @@ describe('Filter', () => {
         it('case insensitive exact match', () => {
           let filter = new Filter;
           let words = {
-            master: { matchMethod: 0, repeat: true, sub: 'padawan' },
-            the: { matchMethod: 1, repeat: true, sub: 'teh' }
+            master: { matchMethod: Constants.MatchMethods.Exact, repeat: true, sub: 'padawan' },
+            the: { matchMethod: Constants.MatchMethods.Partial, repeat: true, sub: 'teh' }
           };
-          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: 1, iWordWhitelist: ['master'] });
+          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FilterMethods.Substitute, iWordWhitelist: ['master'] });
           filter.init();
           expect(filter.replaceText('Can the master outsmart the Master?')).to.equal('Can teh master outsmart teh Master?');
           expect(filter.counter).to.equal(2);
@@ -355,8 +356,8 @@ describe('Filter', () => {
 
         it('case insensitive partial match', () => {
           let filter = new Filter;
-          let words = { more: { matchMethod: 1, repeat: true, sub: 'less' } };
-          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: 1, iWordWhitelist: ['smore'] });
+          let words = { more: { matchMethod: Constants.MatchMethods.Partial, repeat: true, sub: 'less' } };
+          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FilterMethods.Substitute, iWordWhitelist: ['smore'] });
           filter.init();
           expect(filter.replaceText('Would you like sMorE smores?')).to.equal('Would you like sMorE slesss?');
           expect(filter.counter).to.equal(1);
@@ -366,8 +367,8 @@ describe('Filter', () => {
       describe('Unicode characters', () => {
         it('Exact word with substitions marked and preserveCase with repeated characters', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 1, substitutionMark: true, preserveCase: true });
-          filter.cfg.words['врата'] = { matchMethod: 0, repeat: true, sub: 'door' };
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Substitute, substitutionMark: true, preserveCase: true });
+          filter.cfg.words['врата'] = { matchMethod: Constants.MatchMethods.Exact, repeat: true, sub: 'door' };
           filter.init();
           expect(filter.replaceText('this even works on unicode WORDS like Врата, cool huh?')).to.equal('this even works on unicode [IDEA] like [Door], cool huh?');
         });
@@ -378,7 +379,7 @@ describe('Filter', () => {
       describe('Exact', () => {
         it('Update stats', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 2 });
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Remove });
           filter.init();
           expect(filter.counter).to.equal(0);
           expect(filter.replaceText('A cool, example sentence.')).to.equal('A cool, sentence.');
@@ -387,7 +388,7 @@ describe('Filter', () => {
 
         it('Ending with punctuation', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ filterMethod: 2, words: { 'this!': { matchMethod: 0, repeat: false } } });
+          filter.cfg = new Config({ filterMethod: Constants.FilterMethods.Remove, words: { 'this!': { matchMethod: Constants.MatchMethods.Exact, repeat: false } } });
           filter.init();
           expect(filter.replaceText('I love This! Do you?')).to.equal('I love Do you?');
           expect(filter.replaceText('I love this!')).to.equal('I love');
@@ -395,8 +396,8 @@ describe('Filter', () => {
 
         it('With separators', () => {
           let filter = new Filter;
-          let words = { pizza: { matchMethod: 0, repeat: true, separators: true } };
-          filter.cfg = new Config({ words: words, filterMethod: 2, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: true });
+          let words = { pizza: { matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: true } };
+          filter.cfg = new Config({ words: words, filterMethod: Constants.FilterMethods.Remove, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: true });
           filter.init();
           expect(filter.replaceText('I love to eat PPPPPP-I-----ZZZZZZZZZZZ__A!')).to.equal('I love to eat!');
         });
@@ -405,7 +406,7 @@ describe('Filter', () => {
       describe('Partial', () => {
         it('Not update stats', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 2 });
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Remove });
           filter.init();
           expect(filter.counter).to.equal(0);
           expect(filter.replaceText('This Sample is a pretty good sampler to sample.', filter.wordlistId, false)).to.equal('This is a pretty good to.');
@@ -414,7 +415,7 @@ describe('Filter', () => {
 
         it('Ending with punctuation', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ filterMethod: 2, words: { 'this!': { matchMethod: 1, repeat: false } } });
+          filter.cfg = new Config({ filterMethod: Constants.FilterMethods.Remove, words: { 'this!': { matchMethod: Constants.MatchMethods.Partial, repeat: false } } });
           filter.init();
           expect(filter.replaceText('I love allthis! Do you?')).to.equal('I love Do you?');
           expect(filter.replaceText('I love this! Do you?')).to.equal('I love Do you?');
@@ -423,8 +424,8 @@ describe('Filter', () => {
 
       it('Should filter a RegExp', () => {
         let filter = new Filter;
-        filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 2 });
-        filter.cfg.words['this and everything after.*$'] = { matchMethod: 3, repeat: false, sub: 'substitute' };
+        filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Remove });
+        filter.cfg.words['this and everything after.*$'] = { matchMethod: Constants.MatchMethods.Regex, repeat: false, sub: 'substitute' };
         filter.init();
         expect(filter.replaceText('Have you ever done this and everything after it?')).to.equal('Have you ever done ');
       });
@@ -432,8 +433,8 @@ describe('Filter', () => {
       describe('whitelist', () => {
         it('case-sensitive exact match', () => {
           let filter = new Filter;
-          let words = { master: { matchMethod: 0, repeat: true, sub: 'padawan' } };
-          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: 2, wordWhitelist: ['Master'] });
+          let words = { master: { matchMethod: Constants.MatchMethods.Exact, repeat: true, sub: 'padawan' } };
+          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FilterMethods.Remove, wordWhitelist: ['Master'] });
           filter.init();
           expect(filter.replaceText('Can the master outsmart the Master?')).to.equal('Can the outsmart the Master?');
           expect(filter.counter).to.equal(1);
@@ -441,8 +442,8 @@ describe('Filter', () => {
 
         it('case-sensitive partial match', () => {
           let filter = new Filter;
-          let words = { more: { matchMethod: 1, repeat: true } };
-          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: 2, wordWhitelist: ['smores'] });
+          let words = { more: { matchMethod: Constants.MatchMethods.Partial, repeat: true } };
+          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FilterMethods.Remove, wordWhitelist: ['smores'] });
           filter.init();
           expect(filter.replaceText('Would you like smore smores?')).to.equal('Would you like smores?');
           expect(filter.counter).to.equal(1);
@@ -450,8 +451,8 @@ describe('Filter', () => {
 
         it('case-insensitive exact match)', () => {
           let filter = new Filter;
-          let words = { pie: { matchMethod: 0, repeat: true, sub: 'cake' } };
-          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: 2, iWordWhitelist: ['pie'] });
+          let words = { pie: { matchMethod: Constants.MatchMethods.Exact, repeat: true, sub: 'cake' } };
+          filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FilterMethods.Remove, iWordWhitelist: ['pie'] });
           filter.init();
           expect(filter.replaceText('Apple pie is the best PIE!')).to.equal('Apple pie is the best PIE!');
           expect(filter.counter).to.equal(0);
@@ -461,8 +462,8 @@ describe('Filter', () => {
       describe('Unicode characters', () => {
         it('Exact word', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 2 });
-          filter.cfg.words['врата'] = { matchMethod: 0, repeat: true, sub: 'door' };
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Remove });
+          filter.cfg.words['врата'] = { matchMethod: Constants.MatchMethods.Exact, repeat: true, sub: 'door' };
           filter.init();
           expect(filter.replaceText('This even works on врата. cool huh?')).to.equal('This even works on. cool huh?');
           expect(filter.replaceText('This even works on врата, cool huh?')).to.equal('This even works on, cool huh?');
@@ -471,8 +472,8 @@ describe('Filter', () => {
 
         it('Partial word', () => {
           let filter = new Filter;
-          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: 2 });
-          filter.cfg.words['врата'] = { matchMethod: 1, repeat: true, sub: 'door' };
+          filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FilterMethods.Remove });
+          filter.cfg.words['врата'] = { matchMethod: Constants.MatchMethods.Partial, repeat: true, sub: 'door' };
           filter.init();
           expect(filter.replaceText('This even works on with-врата. Cool huh?')).to.equal('This even works on. Cool huh?');
           expect(filter.replaceText('The вратаs in the hat')).to.equal('The in the hat');

--- a/test/lib/word.spec.js
+++ b/test/lib/word.spec.js
@@ -1,4 +1,5 @@
 const expect = require('chai').expect;
+import Constants from '../built/lib/constants';
 import Config from '../built/lib/config';
 import Word from '../built/lib/word';
 
@@ -6,12 +7,12 @@ describe('Word', function() {
   describe('Regular Expressions', function() {
     describe('Exact Matching', function() {
       it('should build RegExp', function() {
-        let word = new Word('word', { matchMethod: 0 }, Config._defaults);
+        let word = new Word('word', { matchMethod: Constants.MatchMethods.Exact }, Config._defaults);
         expect(word.regExp).to.eql(/\bword\b/gi);
       });
 
       it('should build RegExp with matchRepeated', function() {
-        let word = new Word('word', { matchMethod: 0, repeat: true }, Config._defaults);
+        let word = new Word('word', { matchMethod: Constants.MatchMethods.Exact, repeat: true }, Config._defaults);
         expect(word.regExp).to.eql(/\bw+o+r+d+\b/gi);
       });
 
@@ -22,20 +23,20 @@ describe('Word', function() {
       });
 
       it('should build RegExp with ending punctuation', function() {
-        let word = new Word('word!', { matchMethod: 0 }, Config._defaults);
+        let word = new Word('word!', { matchMethod: Constants.MatchMethods.Exact }, Config._defaults);
         expect(word.unicode).to.eql(false);
         expect(word.regExp).to.eql(/(^|\s)(word!)(\s|$)/gi);
       });
 
       it('should build RegExp with matchSeparators and matchRepeated', function() {
-        let word = new Word('word', { matchMethod: 0, repeat: true, separators: true }, Config._defaults);
+        let word = new Word('word', { matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: true }, Config._defaults);
         expect(word.regExp).to.eql(/\bw+[-_ ]*o+[-_ ]*r+[-_ ]*d+\b/gi);
       });
 
       // Work around for lack of word boundary support for unicode characters
       describe('Unicode', function() {
         it('should use workaround for UTF word boundaries', function() {
-          let word = new Word('врата', { matchMethod: 0 }, Config._defaults);
+          let word = new Word('врата', { matchMethod: Constants.MatchMethods.Exact }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]+)(врата)([\\s.,\'"+!?|-]+|$)', 'giu')
@@ -43,7 +44,7 @@ describe('Word', function() {
         });
 
         it('should use workaround for UTF word boundaries with matchRepeated', function() {
-          let word = new Word('врата', { matchMethod: 0, repeat: true }, Config._defaults);
+          let word = new Word('врата', { matchMethod: Constants.MatchMethods.Exact, repeat: true }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]+)(в+р+а+т+а+)([\\s.,\'"+!?|-]+|$)', 'giu')
@@ -54,46 +55,46 @@ describe('Word', function() {
 
     describe('Partial Match', function() {
       it('should build RegExp', function() {
-        let word = new Word('word', { matchMethod: 1 }, Config._defaults);
+        let word = new Word('word', { matchMethod: Constants.MatchMethods.Partial }, Config._defaults);
         expect(word.regExp).to.eql(/word/gi);
       });
 
       it('should build RegExp with matchRepeated', function() {
-        let word = new Word('word', { matchMethod: 1, repeat: true }, Config._defaults);
+        let word = new Word('word', { matchMethod: Constants.MatchMethods.Partial, repeat: true }, Config._defaults);
         expect(word.regExp).to.eql(/w+o+r+d+/gi);
       });
 
       it('should build RegExp with matchSeparators', function() {
-        let word = new Word('word', { matchMethod: 1, separators: true }, Config._defaults);
+        let word = new Word('word', { matchMethod: Constants.MatchMethods.Partial, separators: true }, Config._defaults);
         expect(word.regExp).to.eql(/w[-_ ]*o[-_ ]*r[-_ ]*d/gi);
       });
 
       it('should build RegExp with matchSeparators and matchRepeated', function() {
-        let word = new Word('word', { matchMethod: 1, repeat: true, separators: true }, Config._defaults);
+        let word = new Word('word', { matchMethod: Constants.MatchMethods.Partial, repeat: true, separators: true }, Config._defaults);
         expect(word.regExp).to.eql(/w+[-_ ]*o+[-_ ]*r+[-_ ]*d+/gi);
       });
     });
 
     describe('Remove Exact', function() {
       it('should build RegExp', function() {
-        let word = new Word('word', { matchMethod: 0, _filterMethod: 2 }, Config._defaults);
+        let word = new Word('word', { matchMethod: Constants.MatchMethods.Exact, _filterMethod: Constants.FilterMethods.Remove }, Config._defaults);
         expect(word.regExp).to.eql(/\s?\bword\b\s?/gi);
       });
 
       it('should build RegExp with matchRepeated', function() {
-        let word = new Word('word', { matchMethod: 0, repeat: true, _filterMethod: 2 }, Config._defaults);
+        let word = new Word('word', { matchMethod: Constants.MatchMethods.Exact, repeat: true, _filterMethod: Constants.FilterMethods.Remove }, Config._defaults);
         expect(word.regExp).to.eql(/\s?\bw+o+r+d+\b\s?/gi);
       });
 
       it('should build RegExp with ending punctuation', function() {
-        let word = new Word('word!', { matchMethod: 0, _filterMethod: 2 }, Config._defaults);
+        let word = new Word('word!', { matchMethod: Constants.MatchMethods.Exact, _filterMethod: Constants.FilterMethods.Remove }, Config._defaults);
         expect(word.regExp).to.eql(/(^|\s)(word!)(\s|$)/gi);
       });
 
       // Work around for lack of word boundary support for unicode characters
       describe('Unicode', function() {
         it('should build RegExp', function() {
-          let word = new Word('куче', { matchMethod: 0, _filterMethod: 2 }, Config._defaults);
+          let word = new Word('куче', { matchMethod: Constants.MatchMethods.Exact, _filterMethod: Constants.FilterMethods.Remove }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-])(куче)([\\s.,\'"+!?|-]|$)', 'giu')
@@ -101,7 +102,7 @@ describe('Word', function() {
         });
 
         it('should build RegExp with matchRepeated', function() {
-          let word = new Word('куче', { matchMethod: 0, repeat: true, _filterMethod: 2 }, Config._defaults);
+          let word = new Word('куче', { matchMethod: Constants.MatchMethods.Exact, repeat: true, _filterMethod: Constants.FilterMethods.Remove }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-])(к+у+ч+е+)([\\s.,\'"+!?|-]|$)', 'giu')
@@ -112,24 +113,24 @@ describe('Word', function() {
 
     describe('Remove Partial Match', function() {
       it('should build RegExp', function() {
-        let word = new Word('word', { matchMethod: 1 }, Object.assign(Config._defaults, { filterMethod: 2 }));
+        let word = new Word('word', { matchMethod: Constants.MatchMethods.Partial }, Object.assign(Config._defaults, { filterMethod: Constants.FilterMethods.Remove }));
         expect(word.regExp).to.eql(/\s?\b[\w-]*word[\w-]*\b\s?/gi);
       });
 
       it('should build RegExp with matchRepeated', function() {
-        let word = new Word('word', { matchMethod: 1, repeat: true }, Object.assign(Config._defaults, { filterMethod: 2 }));
+        let word = new Word('word', { matchMethod: Constants.MatchMethods.Partial, repeat: true }, Object.assign(Config._defaults, { filterMethod: Constants.FilterMethods.Remove }));
         expect(word.regExp).to.eql(/\s?\b[\w-]*w+o+r+d+[\w-]*\b\s?/gi);
       });
 
       it('should build RegExp with ending punctuation', function() {
-        let word = new Word('word!', { matchMethod: 1 }, Object.assign(Config._defaults, { filterMethod: 2 }));
+        let word = new Word('word!', { matchMethod: Constants.MatchMethods.Partial }, Object.assign(Config._defaults, { filterMethod: Constants.FilterMethods.Remove }));
         expect(word.regExp).to.eql(/(^|\s)([\w-]*word![\w-]*)(\s|$)/gi);
       });
 
       // Work around for lack of word boundary support for unicode characters
       describe('Unicode', function() {
         it('should build RegExp', function() {
-          let word = new Word('куче', { matchMethod: 1 }, Object.assign(Config._defaults, { filterMethod: 2 }));
+          let word = new Word('куче', { matchMethod: Constants.MatchMethods.Partial }, Object.assign(Config._defaults, { filterMethod: Constants.FilterMethods.Remove }));
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]?)([\\w-]*куче[\\w-]*)([\\s.,\'"+!?|-]?|$)', 'giu')
@@ -137,7 +138,7 @@ describe('Word', function() {
         });
 
         it('should build RegExp with matchRepeated', function() {
-          let word = new Word('куче', { matchMethod: 1, repeat: true }, Object.assign(Config._defaults, { filterMethod: 2 }));
+          let word = new Word('куче', { matchMethod: Constants.MatchMethods.Partial, repeat: true }, Object.assign(Config._defaults, { filterMethod: Constants.FilterMethods.Remove }));
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]?)([\\w-]*к+у+ч+е+[\\w-]*)([\\s.,\'"+!?|-]?|$)', 'giu')
@@ -148,24 +149,24 @@ describe('Word', function() {
 
     describe('Whole Match', function() {
       it('should build RegExp', function() {
-        let word = new Word('word', { matchMethod: 2 }, Config._defaults);
+        let word = new Word('word', { matchMethod: Constants.MatchMethods.Whole }, Config._defaults);
         expect(word.regExp).to.eql(/\b[\w-]*word[\w-]*\b/gi);
       });
 
       it('should build RegExp with matchRepeated', function() {
-        let word = new Word('word', { matchMethod: 2, repeat: true }, Config._defaults);
+        let word = new Word('word', { matchMethod: Constants.MatchMethods.Whole, repeat: true }, Config._defaults);
         expect(word.regExp).to.eql(/\b[\w-]*w+o+r+d+[\w-]*\b/gi);
       });
 
       it('should build RegExp with ending punctuation', function() {
-        let word = new Word('word!', { matchMethod: 2 }, Config._defaults);
+        let word = new Word('word!', { matchMethod: Constants.MatchMethods.Whole }, Config._defaults);
         expect(word.regExp).to.eql(/(^|\s)([\S]*word![\S]*)(\s|$)/gi);
       });
 
       // Work around for lack of word boundary support for unicode characters
       describe('Unicode', function() {
         it('should build RegExp', function() {
-          let word = new Word('куче', { matchMethod: 2 }, Config._defaults);
+          let word = new Word('куче', { matchMethod: Constants.MatchMethods.Whole }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]*)([\\S]*куче[\\S]*)([\\s.,\'"+!?|-]*|$)', 'giu')
@@ -173,7 +174,7 @@ describe('Word', function() {
         });
 
         it('should build RegExp with matchRepeated', function() {
-          let word = new Word('куче', { matchMethod: 2, repeat: true }, Config._defaults);
+          let word = new Word('куче', { matchMethod: Constants.MatchMethods.Whole, repeat: true }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]*)([\\S]*к+у+ч+е+[\\S]*)([\\s.,\'"+!?|-]*|$)', 'giu')
@@ -181,7 +182,7 @@ describe('Word', function() {
         });
 
         it('should build RegExp with matchRepeated and matchSeparators', function() {
-          let word = new Word('куче', { matchMethod: 2, repeat: true, separators: true }, Config._defaults);
+          let word = new Word('куче', { matchMethod: Constants.MatchMethods.Whole, repeat: true, separators: true }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]*)([\\S]*к+[-_ ]*у+[-_ ]*ч+[-_ ]*е+[\\S]*)([\\s.,\'"+!?|-]*|$)', 'giu')
@@ -233,18 +234,18 @@ describe('Word', function() {
 
   describe('constructor()', function() {
     it('should use all provided defaults', function() {
-      let cfg = Object.assign({}, Config._defaults, { defaultWordMatchMethod: 2 });
+      let cfg = Object.assign({}, Config._defaults, { defaultWordMatchMethod: Constants.MatchMethods.Whole });
       let options = {};
       let word = new Word('train', options, cfg);
-      expect(word.matchMethod).to.eql(2);
+      expect(word.matchMethod).to.eql(Constants.MatchMethods.Whole);
       expect(word.matchRepeated).to.eql(cfg.defaultWordRepeat);
       expect(word.lists).to.eql([]);
       expect(word.matchSeparators).to.eql(cfg.defaultWordSeparators);
     });
 
-    it('should use provided matchMethod = 0 and fill in defaults', function() {
-      let cfg = Object.assign({}, Config._defaults, { defaultWordMatchMethod: 2 });
-      let options = { lists: [1,5], matchMethod: 0, repeat: true };
+    it('should use provided matchMethod (Exact) and fill in defaults', function() {
+      let cfg = Object.assign({}, Config._defaults, { defaultWordMatchMethod: Constants.MatchMethods.Whole });
+      let options = { lists: [1,5], matchMethod: Constants.MatchMethods.Exact, repeat: true };
       let word = new Word('again', options, cfg);
       expect(word.matchMethod).to.eql(options.matchMethod);
       expect(word.matchRepeated).to.eql(options.repeat);
@@ -252,9 +253,9 @@ describe('Word', function() {
       expect(word.matchSeparators).to.eql(cfg.defaultWordSeparators);
     });
 
-    it('should use provided matchMethod = 2 and fill in defaults', function() {
+    it('should use provided matchMethod (Whole) and fill in defaults', function() {
       let cfg = Config._defaults;
-      let options = { matchMethod: 2, separators: true };
+      let options = { matchMethod: Constants.MatchMethods.Whole, separators: true };
       let word = new Word('testing', options, cfg);
       expect(word.matchMethod).to.eql(options.matchMethod);
       expect(word.matchRepeated).to.eql(cfg.defaultWordRepeat);

--- a/test/lib/wordlist.spec.js
+++ b/test/lib/wordlist.spec.js
@@ -1,11 +1,12 @@
 const expect = require('chai').expect;
+import Constants from '../built/lib/constants';
 import Wordlist from '../built/lib/wordlist';
 
 const testWords = {
-  'example': { lists: [1], matchMethod: 0, repeat: true, sub: 'demo' },
-  'placeholder': { lists: [1,2], matchMethod: 0, repeat: false, sub: 'variable' },
-  'sample': { lists: [2], matchMethod: 1, repeat: false, sub: 'piece' },
-  'word': { matchMethod: 2, repeat: true, sub: 'idea' }
+  'example': { lists: [1], matchMethod: Constants.MatchMethods.Exact, repeat: true, sub: 'demo' },
+  'placeholder': { lists: [1,2], matchMethod: Constants.MatchMethods.Exact, repeat: false, sub: 'variable' },
+  'sample': { lists: [2], matchMethod: Constants.MatchMethods.Partial, repeat: false, sub: 'piece' },
+  'word': { matchMethod: Constants.MatchMethods.Whole, repeat: true, sub: 'idea' }
 };
 
 describe('Wordlist', function() {

--- a/test/webConfig.spec.js
+++ b/test/webConfig.spec.js
@@ -1,4 +1,5 @@
 const expect = require('chai').expect;
+import Constants from './built/lib/constants';
 import WebConfig from './built/webConfig';
 
 describe('WebConfig', function() {
@@ -25,12 +26,12 @@ describe('WebConfig', function() {
     it('should combine _words# data', function() {
       let config = new WebConfig(WebConfig._defaults);
       config._words0 = WebConfig._defaultWords;
-      config._words1 = { 'test': { lists: [], matchMethod: 0, repeat: true, separators: false, sub: 'tset' } };
+      config._words1 = { 'test': { lists: [], matchMethod: Constants.MatchMethods.Exact, repeat: true, separators: false, sub: 'tset' } };
       config._splitContainerKeys = ['words'];
       expect(config.words).to.not.exist;
       let combinedKeys = WebConfig.combineData(config, 'words');
       expect(combinedKeys).to.eql(['_words0', '_words1']);
-      expect(config.words['test'].matchMethod).to.eq(0);
+      expect(config.words['test'].matchMethod).to.eq(Constants.MatchMethods.Exact);
       expect(config.words[Object.keys(WebConfig._defaultWords)[0]]).to.exist;
       expect(config.words['undefined']).to.not.exist;
       expect(config._words0).to.not.exist;


### PR DESCRIPTION
## 🐛 Bugs Fixed:
- Fix Regular Expression matches (#218)

## 🔧 Development:
- Switched default from partial to exact when no `matchMethod` is specified on `replaceText()`
- Removed magic numbers for FilterMethods, MatchMethods, MuteMethods, ShowSubtitles
