### PR TITLE
Substitution Capitalization and Improve Preserve Case

### DIFF
--- a/src/script/dataMigration.ts
+++ b/src/script/dataMigration.ts
@@ -16,7 +16,7 @@ export default class DataMigration {
     { version: '2.7.0', name: 'removeGlobalMatchMethod', runOnImport: true },
     { version: '2.7.0', name: 'removeOldDomainArrays', runOnImport: true },
     { version: '2.12.0', name: 'overwriteMuteCueRequireShowingDefault', runOnImport: false },
-    { version: '2.22.0', name: 'updateWordRepeatAndSeparatorTypes', runOnImport: true },
+    { version: '2.22.0', name: 'updateWordRepeatAndSeparatorDataTypes', runOnImport: true },
   ];
 
   constructor(config) {
@@ -199,8 +199,8 @@ export default class DataMigration {
     });
   }
 
-  // [2.22.0] - Update word repeat and separator types
-  updateWordRepeatAndSeparatorTypes() {
+  // [2.22.0] - Update word repeat and separator data types
+  updateWordRepeatAndSeparatorDataTypes() {
     const cfg = this.cfg;
 
     Object.keys(cfg.words).forEach((word) => {

--- a/src/script/dataMigration.ts
+++ b/src/script/dataMigration.ts
@@ -1,5 +1,5 @@
 import Constants from './lib/constants';
-import { getVersion, isVersionOlder } from './lib/helper';
+import { booleanToNumber, getVersion, isVersionOlder } from './lib/helper';
 import WebConfig from './webConfig';
 
 export default class DataMigration {
@@ -16,6 +16,7 @@ export default class DataMigration {
     { version: '2.7.0', name: 'removeGlobalMatchMethod', runOnImport: true },
     { version: '2.7.0', name: 'removeOldDomainArrays', runOnImport: true },
     { version: '2.12.0', name: 'overwriteMuteCueRequireShowingDefault', runOnImport: false },
+    { version: '2.22.0', name: 'updateWordRepeatAndSeparatorTypes', runOnImport: true },
   ];
 
   constructor(config) {
@@ -194,6 +195,29 @@ export default class DataMigration {
         if (wordObj.sub == updatedWords[updatedWord].original) {
           wordObj.sub = updatedWords[updatedWord].update;
         }
+      }
+    });
+  }
+
+  // [2.22.0] - Update word repeat and separator types
+  updateWordRepeatAndSeparatorTypes() {
+    const cfg = this.cfg;
+
+    Object.keys(cfg.words).forEach((word) => {
+      const wordOptions = cfg.words[word] as WordOptions;
+
+      // @ts-ignore: Converting repeat from boolean to number
+      if (wordOptions.repeat === true || wordOptions.repeat === false) {
+        wordOptions.repeat = booleanToNumber(wordOptions.repeat);
+      } else if (wordOptions.repeat == null) {
+        wordOptions.repeat = cfg.defaultWordRepeat;
+      }
+
+      // @ts-ignore: Converting separators from boolean to number
+      if (wordOptions.separators === true || wordOptions.separators === false) {
+        wordOptions.separators = booleanToNumber(wordOptions.separators);
+      } else if (wordOptions.separators == null) {
+        wordOptions.separators = cfg.defaultWordSeparators;
       }
     });
   }

--- a/src/script/lib/config.ts
+++ b/src/script/lib/config.ts
@@ -95,7 +95,7 @@ export default class Config {
     if (Object.keys(this.words).includes(str)) {
       return false; // Already exists
     } else {
-      options.sub = options.sub.trim().toLowerCase();
+      options.sub = options.case ? options.sub.trim() : options.sub.trim().toLowerCase();
       this.words[str] = options;
       return true;
     }

--- a/src/script/lib/config.ts
+++ b/src/script/lib/config.ts
@@ -5,8 +5,8 @@ export default class Config {
   censorFixedLength: number;
   defaultSubstitution: string;
   defaultWordMatchMethod: number;
-  defaultWordRepeat: boolean;
-  defaultWordSeparators: boolean;
+  defaultWordRepeat: number;
+  defaultWordSeparators: number;
   filterMethod: number;
   filterWordList: boolean;
   iWordWhitelist: string[];
@@ -29,8 +29,8 @@ export default class Config {
     censorFixedLength: 0,
     defaultSubstitution: 'censored',
     defaultWordMatchMethod: Constants.MATCH_METHODS.EXACT,
-    defaultWordRepeat: false,
-    defaultWordSeparators: false,
+    defaultWordRepeat: Constants.FALSE,
+    defaultWordSeparators: Constants.FALSE,
     filterMethod: Constants.FILTER_METHODS.SUBSTITUTE,
     filterWordList: true,
     iWordWhitelist: [],
@@ -47,37 +47,37 @@ export default class Config {
   };
 
   static readonly _defaultWords: { [key: string]: WordOptions } = {
-    'ass': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, separators: false, sub: 'butt' },
-    'asses': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: false, separators: false, sub: 'butts' },
-    'asshole': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: false, sub: 'jerk' },
-    'badass': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: true, sub: 'cool' },
-    'bastard': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: false, sub: 'idiot' },
-    'bitch': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: false, sub: 'bench' },
-    'cocksucker': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: true, sub: 'suckup' },
-    'cunt': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: false, sub: 'expletive' },
-    'dammit': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: false, separators: true, sub: 'dangit' },
-    'damn': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: false, separators: false, sub: 'dang' },
-    'dumbass': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: false, sub: 'idiot' },
-    'fag': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, separators: false, sub: 'gay' },
-    'faggot': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: false, sub: 'gay' },
-    'fags': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, separators: false, sub: 'gays' },
-    'fuck': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: true, sub: 'freak' },
-    'goddammit': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: true, sub: 'dangit' },
-    'hell': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: false, separators: false, sub: 'heck' },
-    'jackass': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: true, sub: 'jerk' },
-    'nigga': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, separators: false, sub: 'bruh' },
-    'nigger': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, separators: false, sub: 'man' },
-    'niggers': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, separators: false, sub: 'people' },
-    'piss': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: false, sub: 'pee' },
-    'pissed': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: false, sub: 'ticked' },
-    'pussies': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, separators: false, sub: 'softies' },
-    'pussy': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, separators: false, sub: 'softie' },
-    'shit': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: false, sub: 'crap' },
-    'slut': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: false, sub: 'tramp' },
-    'tits': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: false, sub: 'chest' },
-    'twat': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, separators: false, sub: 'dumbo' },
-    'twats': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, separators: false, sub: 'dumbos' },
-    'whore': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: false, sub: 'tramp' },
+    'ass': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'butt' },
+    'asses': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.FALSE, separators: Constants.FALSE, sub: 'butts' },
+    'asshole': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'jerk' },
+    'badass': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.TRUE, sub: 'cool' },
+    'bastard': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'idiot' },
+    'bitch': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'bench' },
+    'cocksucker': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.TRUE, sub: 'suckup' },
+    'cunt': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'expletive' },
+    'dammit': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.FALSE, separators: Constants.TRUE, sub: 'dangit' },
+    'damn': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.FALSE, separators: Constants.FALSE, sub: 'dang' },
+    'dumbass': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'idiot' },
+    'fag': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'gay' },
+    'faggot': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'gay' },
+    'fags': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'gays' },
+    'fuck': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.TRUE, sub: 'freak' },
+    'goddammit': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.TRUE, sub: 'dangit' },
+    'hell': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.FALSE, separators: Constants.FALSE, sub: 'heck' },
+    'jackass': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.TRUE, sub: 'jerk' },
+    'nigga': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'bruh' },
+    'nigger': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'man' },
+    'niggers': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'people' },
+    'piss': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'pee' },
+    'pissed': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'ticked' },
+    'pussies': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'softies' },
+    'pussy': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'softie' },
+    'shit': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'crap' },
+    'slut': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'tramp' },
+    'tits': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'chest' },
+    'twat': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'dumbo' },
+    'twats': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'dumbos' },
+    'whore': { lists: [], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'tramp' },
   };
 
   constructor(data: Record<string, unknown> = {}) {
@@ -126,8 +126,8 @@ export default class Config {
     }
   }
 
-  repeatForWord(word: string): boolean {
-    if (this.words[word].repeat === true || this.words[word].repeat === false) {
+  repeatForWord(word: string): number {
+    if (this.words[word].repeat === Constants.TRUE || this.words[word].repeat === Constants.FALSE) {
       return this.words[word].repeat;
     } else {
       return this.defaultWordRepeat;

--- a/src/script/lib/constants.ts
+++ b/src/script/lib/constants.ts
@@ -5,12 +5,14 @@ export default class Constants {
   // Named Constants
   static readonly ALL_WORDS_WORDLIST_ID = 0;
   static readonly DOMAIN_MODES = { NORMAL: 0, ADVANCED: 1, DEEP: 2 };
+  static readonly FALSE = 0;
   static readonly FILTER_METHODS = { CENSOR: 0, SUBSTITUTE: 1, REMOVE: 2 };
   static readonly MATCH_METHODS = { EXACT: 0, PARTIAL: 1, WHOLE: 2, REGEX: 3 };
   static readonly MUTE_METHODS = { TAB: 0, VIDEO: 1, NONE: 2 };
   static readonly SHOW_SUBTITLES = { ALL: 0, FILTERED: 1, UNFILTERED: 2, NONE: 3 };
   static readonly STATS_TYPE_AUDIO = 'audio';
   static readonly STATS_TYPE_TEXT = 'text';
+  static readonly TRUE = 1;
 
   // Helper Functions
   static filterMethodName(id: number) { return this.nameById(this.FILTER_METHODS, id); }

--- a/src/script/lib/filter.ts
+++ b/src/script/lib/filter.ts
@@ -144,7 +144,7 @@ export default class Filter {
             let sub = word.sub || this.cfg.defaultSubstitution;
 
             // Make substitution match case of original match
-            if (this.cfg.preserveCase) {
+            if (!word.case && this.cfg.preserveCase) {
               if (Word.allUpperCase(match)) {
                 sub = sub.toUpperCase();
               } else if (Word.capitalized(match)) {

--- a/src/script/lib/filter.ts
+++ b/src/script/lib/filter.ts
@@ -147,8 +147,8 @@ export default class Filter {
             if (!word.case && this.cfg.preserveCase) {
               if (Word.allUpperCase(match)) {
                 sub = sub.toUpperCase();
-              } else if (Word.eachCapitalized(match)) {
-                sub = Word.capitalizeEachFirst(sub);
+              } else if (Word.eachWordCapitalized(match)) {
+                sub = Word.capitalizeEachWord(sub);
               } else if (Word.firstCapitalized(match)) {
                 sub = Word.capitalizeFirst(sub);
               }

--- a/src/script/lib/filter.ts
+++ b/src/script/lib/filter.ts
@@ -147,8 +147,10 @@ export default class Filter {
             if (!word.case && this.cfg.preserveCase) {
               if (Word.allUpperCase(match)) {
                 sub = sub.toUpperCase();
-              } else if (Word.capitalized(match)) {
-                sub = Word.capitalize(sub);
+              } else if (Word.eachCapitalized(match)) {
+                sub = Word.capitalizeEachFirst(sub);
+              } else if (Word.firstCapitalized(match)) {
+                sub = Word.capitalizeFirst(sub);
               }
             }
 

--- a/src/script/lib/filter.ts
+++ b/src/script/lib/filter.ts
@@ -44,8 +44,8 @@ export default class Filter {
       if (word.matchMethod === Constants.MATCH_METHODS.PARTIAL) {
         const wordOptions: WordOptions = {
           matchMethod: Constants.MATCH_METHODS.WHOLE,
-          repeat: false,
-          separators: false,
+          repeat: Constants.FALSE,
+          separators: Constants.FALSE,
           sub: ''
         };
         const wholeWordRegExp = new Word(match, wordOptions, this.cfg).regExp;

--- a/src/script/lib/globals.d.ts
+++ b/src/script/lib/globals.d.ts
@@ -149,8 +149,8 @@ interface WordOptions {
   case?: number;
   lists?: number[];
   matchMethod: number;
-  repeat: boolean;
-  separators?: boolean;
+  repeat: number;
+  separators?: number;
   sub: string;
 }
 

--- a/src/script/lib/globals.d.ts
+++ b/src/script/lib/globals.d.ts
@@ -146,6 +146,7 @@ interface WatcherData {
 
 interface WordOptions {
   _filterMethod?: number;  // This should not be stored in the config. Only there for new Word
+  case?: number;
   lists?: number[];
   matchMethod: number;
   repeat: boolean;

--- a/src/script/lib/helper.ts
+++ b/src/script/lib/helper.ts
@@ -1,3 +1,9 @@
+import Constants from './constants';
+
+export function booleanToNumber(value: boolean): number {
+  return value ? Constants.TRUE : Constants.FALSE;
+}
+
 /* istanbul ignore next */
 export function dynamicList(list: string[], select: HTMLSelectElement, upperCaseFirstChar: boolean = false, title?: string) {
   removeChildren(select);
@@ -111,6 +117,10 @@ export function makeRequest(method: string, url: string) {
     };
     xhr.send();
   });
+}
+
+export function numberToBoolean(value: number): boolean {
+  return value > Constants.FALSE;
 }
 
 export function numberWithCommas(number: number | string): string {

--- a/src/script/lib/word.ts
+++ b/src/script/lib/word.ts
@@ -30,12 +30,15 @@ export default class Word {
     return string.toUpperCase() === string;
   }
 
-  static capitalize(string: string): string {
-    return string.charAt(0).toUpperCase() + string.substr(1);
+  // Note: Requires the input string to be all lower case
+  static capitalizeEachFirst(string: string): string {
+    const split = string.split(/[-_ ]+/i);
+    split.forEach((word) => { string = string.replace(word, this.capitalizeFirst(word)); });
+    return string;
   }
 
-  static capitalized(string: string): boolean {
-    return string.charAt(0).toUpperCase() === string.charAt(0);
+  static capitalizeFirst(string: string): string {
+    return string.charAt(0).toUpperCase() + string.substr(1);
   }
 
   static containsDoubleByte(str): boolean {
@@ -44,11 +47,24 @@ export default class Word {
     return Word._unicodeRegExp.test(str);
   }
 
+  static eachCapitalized(string: string): boolean {
+    const split = string.split(/[-_ ]+/i);
+    if (split.length > 1) {
+      const each = split.every((word) => this.firstCapitalized(word));
+      return each;
+    }
+    return false;
+  }
+
   // /[-\/\\^$*+?.()|[\]{}]/g
   // /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g
   // Removing '-' for '/пресс-релиз/, giu'
   static escapeRegExp(str: string): string {
     return str.replace(Word._escapeRegExp, '\\$&');
+  }
+
+  static firstCapitalized(string: string): boolean {
+    return string.charAt(0).toUpperCase() === string.charAt(0);
   }
 
   constructor(word: string, options: WordOptions, cfg: Config) {

--- a/src/script/lib/word.ts
+++ b/src/script/lib/word.ts
@@ -49,11 +49,7 @@ export default class Word {
 
   static eachWordCapitalized(string: string): boolean {
     const split = string.split(/[-_ ]+/i);
-    if (split.length > 1) {
-      const each = split.every((word) => this.firstCapitalized(word));
-      return each;
-    }
-    return false;
+    return split.every((word) => this.firstCapitalized(word));
   }
 
   // /[-\/\\^$*+?.()|[\]{}]/g

--- a/src/script/lib/word.ts
+++ b/src/script/lib/word.ts
@@ -31,7 +31,7 @@ export default class Word {
   }
 
   // Note: Requires the input string to be all lower case
-  static capitalizeEachFirst(string: string): string {
+  static capitalizeEachWord(string: string): string {
     const split = string.split(/[-_ ]+/i);
     split.forEach((word) => { string = string.replace(word, this.capitalizeFirst(word)); });
     return string;
@@ -47,7 +47,7 @@ export default class Word {
     return Word._unicodeRegExp.test(str);
   }
 
-  static eachCapitalized(string: string): boolean {
+  static eachWordCapitalized(string: string): boolean {
     const split = string.split(/[-_ ]+/i);
     if (split.length > 1) {
       const each = split.every((word) => this.firstCapitalized(word));

--- a/src/script/lib/word.ts
+++ b/src/script/lib/word.ts
@@ -69,7 +69,7 @@ export default class Word {
 
   constructor(word: string, options: WordOptions, cfg: Config) {
     this.value = word;
-    this.case = options.case > 0 ? 1 : 0;
+    this.case = options.case > Constants.FALSE ? Constants.TRUE : Constants.FALSE;
     this.lists = options.lists === undefined ? [] : options.lists;
     this.matchMethod = options.matchMethod === undefined ? cfg.defaultWordMatchMethod : options.matchMethod;
     this.matchRepeated = options.repeat === undefined ? cfg.defaultWordRepeat : options.repeat;

--- a/src/script/lib/word.ts
+++ b/src/script/lib/word.ts
@@ -7,8 +7,8 @@ export default class Word {
   escaped: string;
   lists: number[];
   matchMethod: number;
-  matchRepeated: boolean;
-  matchSeparators: boolean;
+  matchRepeated: number;
+  matchSeparators: number;
   regExp: RegExp;
   sub: string;
   unicode: boolean;

--- a/src/script/lib/word.ts
+++ b/src/script/lib/word.ts
@@ -3,6 +3,7 @@ import Config from './config';
 
 export default class Word {
   _filterMethod: number;
+  case?: number;
   escaped: string;
   lists: number[];
   matchMethod: number;
@@ -52,6 +53,7 @@ export default class Word {
 
   constructor(word: string, options: WordOptions, cfg: Config) {
     this.value = word;
+    this.case = options.case > 0 ? 1 : 0;
     this.lists = options.lists === undefined ? [] : options.lists;
     this.matchMethod = options.matchMethod === undefined ? cfg.defaultWordMatchMethod : options.matchMethod;
     this.matchRepeated = options.repeat === undefined ? cfg.defaultWordRepeat : options.repeat;

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -1,5 +1,5 @@
 import Constants from './lib/constants';
-import { dynamicList, exportToFile, numberWithCommas, readFile, removeChildren, removeFromArray, upperCaseFirst } from './lib/helper';
+import { booleanToNumber, dynamicList, exportToFile, numberToBoolean, numberWithCommas, readFile, removeChildren, removeFromArray, upperCaseFirst } from './lib/helper';
 import WebConfig from './webConfig';
 import Filter from './lib/filter';
 import Domain from './domain';
@@ -224,13 +224,13 @@ export default class OptionPage {
     const repeatInput = document.createElement('input');
     repeatInput.type = 'checkbox';
     repeatInput.name = 'repeat';
-    repeatInput.checked = data.repeat;
+    repeatInput.checked = numberToBoolean(data.repeat);
     cellRepeat.appendChild(repeatInput);
 
     const separatorsInput = document.createElement('input');
     separatorsInput.type = 'checkbox';
     separatorsInput.name = 'separators';
-    separatorsInput.checked = data.separators;
+    separatorsInput.checked =  numberToBoolean(data.separators);
     cellSeparators.appendChild(separatorsInput);
 
     this.cfg.wordlists.forEach((wordlist, index) => {
@@ -305,8 +305,8 @@ export default class OptionPage {
         const wordOptions: WordOptions = {
           lists: lists,
           matchMethod: (cells[3].querySelector('select') as HTMLSelectElement).selectedIndex,
-          repeat: (cells[4].querySelector('input') as HTMLInputElement).checked,
-          separators: (cells[5].querySelector('input') as HTMLInputElement).checked,
+          repeat: booleanToNumber((cells[4].querySelector('input') as HTMLInputElement).checked),
+          separators: booleanToNumber((cells[5].querySelector('input') as HTMLInputElement).checked),
           sub: (cells[2].querySelector('input') as HTMLInputElement).value
         };
         const success = this.cfg.addWord(name, wordOptions);
@@ -715,8 +715,8 @@ export default class OptionPage {
     const defaultWordMatchMethodSelect = document.getElementById('defaultWordMatchMethodSelect') as HTMLSelectElement;
     const defaultWordRepeat = document.getElementById('defaultWordRepeat') as HTMLInputElement;
     const defaultWordSeparators = document.getElementById('defaultWordSeparators') as HTMLInputElement;
-    defaultWordRepeat.checked = this.cfg.defaultWordRepeat;
-    defaultWordSeparators.checked = this.cfg.defaultWordSeparators;
+    defaultWordRepeat.checked = numberToBoolean(this.cfg.defaultWordRepeat);
+    defaultWordSeparators.checked = numberToBoolean(this.cfg.defaultWordSeparators);
     const defaultWordSubstitution = document.getElementById('defaultWordSubstitutionText') as HTMLInputElement;
     defaultWordSubstitution.value = this.cfg.defaultSubstitution;
     removeChildren(defaultWordMatchMethodSelect);
@@ -865,8 +865,8 @@ export default class OptionPage {
       OptionPage.disableBtn(wordRemove);
       const selectedMatchMethod = document.getElementById(`wordMatch${upperCaseFirst(Constants.matchMethodName(this.cfg.defaultWordMatchMethod))}`) as HTMLInputElement;
       selectedMatchMethod.checked = true;
-      wordMatchRepeated.checked = this.cfg.defaultWordRepeat;
-      wordMatchSeparators.checked = this.cfg.defaultWordSeparators;
+      wordMatchRepeated.checked = numberToBoolean(this.cfg.defaultWordRepeat);
+      wordMatchSeparators.checked = numberToBoolean(this.cfg.defaultWordSeparators);
       substitutionText.value = '';
       substitutionCase.checked = false;
       wordlistSelections.forEach((wordlist, index) => {
@@ -884,8 +884,8 @@ export default class OptionPage {
       wordText.value = word;
       const selectedMatchMethod = document.getElementById(`wordMatch${upperCaseFirst(Constants.matchMethodName(wordCfg.matchMethod))}`) as HTMLInputElement;
       selectedMatchMethod.checked = true;
-      wordMatchRepeated.checked = wordCfg.repeat;
-      wordMatchSeparators.checked = wordCfg.separators === undefined ? this.cfg.defaultWordSeparators : wordCfg.separators;
+      wordMatchRepeated.checked = numberToBoolean(wordCfg.repeat);
+      wordMatchSeparators.checked = numberToBoolean(wordCfg.separators === undefined ? this.cfg.defaultWordSeparators : wordCfg.separators);
       substitutionText.value = wordCfg.sub;
       substitutionCase.checked = wordCfg.case > 0;
       wordlistSelections.forEach((wordlist, index) => {
@@ -1174,8 +1174,8 @@ export default class OptionPage {
     this.cfg.censorCharacter = censorCharacterSelect.value;
     this.cfg.censorFixedLength = censorFixedLengthSelect.selectedIndex;
     this.cfg.defaultWordMatchMethod = defaultWordMatchMethodSelect.selectedIndex;
-    this.cfg.defaultWordRepeat = defaultWordRepeat.checked;
-    this.cfg.defaultWordSeparators = defaultWordSeparators.checked;
+    this.cfg.defaultWordRepeat = booleanToNumber(defaultWordRepeat.checked);
+    this.cfg.defaultWordSeparators = booleanToNumber(defaultWordSeparators.checked);
     this.cfg.preserveCase = preserveCase.checked;
     this.cfg.preserveFirst = preserveFirst.checked;
     this.cfg.preserveLast = preserveLast.checked;
@@ -1312,8 +1312,8 @@ export default class OptionPage {
         case: subCase,
         lists: lists,
         matchMethod: matchMethod,
-        repeat: wordMatchRepeated.checked,
-        separators: wordMatchSeparators.checked,
+        repeat: booleanToNumber(wordMatchRepeated.checked),
+        separators: booleanToNumber(wordMatchSeparators.checked),
         sub: sub,
       };
 

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -852,6 +852,7 @@ export default class OptionPage {
     const wordMatchRepeated = document.getElementById('wordMatchRepeated') as HTMLInputElement;
     const wordMatchSeparators = document.getElementById('wordMatchSeparators') as HTMLInputElement;
     const substitutionText = document.getElementById('substitutionText') as HTMLInputElement;
+    const substitutionCase = document.getElementById('substitutionCase') as HTMLInputElement;
     const wordRemove = document.getElementById('wordRemove') as HTMLInputElement;
     const word = wordList.value;
     const wordWordlistDiv = document.getElementById('wordWordlistDiv') as HTMLSelectElement;
@@ -867,6 +868,7 @@ export default class OptionPage {
       wordMatchRepeated.checked = this.cfg.defaultWordRepeat;
       wordMatchSeparators.checked = this.cfg.defaultWordSeparators;
       substitutionText.value = '';
+      substitutionCase.checked = false;
       wordlistSelections.forEach((wordlist, index) => {
         wordlist.checked = (
           index == (this.cfg.wordlistId - 1)
@@ -885,6 +887,7 @@ export default class OptionPage {
       wordMatchRepeated.checked = wordCfg.repeat;
       wordMatchSeparators.checked = wordCfg.separators === undefined ? this.cfg.defaultWordSeparators : wordCfg.separators;
       substitutionText.value = wordCfg.sub;
+      substitutionCase.checked = wordCfg.case > 0;
       wordlistSelections.forEach((wordlist, index) => {
         wordlist.checked = wordCfg.lists.includes(index + 1);
       });
@@ -1277,11 +1280,13 @@ export default class OptionPage {
     const wordMatchRepeated = document.getElementById('wordMatchRepeated') as HTMLInputElement;
     const wordMatchSeparators = document.getElementById('wordMatchSeparators') as HTMLInputElement;
     const substitutionText = document.getElementById('substitutionText') as HTMLInputElement;
+    const substitutionCase = document.getElementById('substitutionCase') as HTMLInputElement;
     const selectedMatchMethod = document.querySelector('input[name="wordMatchMethod"]:checked') as HTMLInputElement;
-    let word = wordText.value.trim();
-    const sub = substitutionText.value.trim().toLowerCase();
-    let added = true;
     const wordlistSelectionsInput = document.querySelectorAll('div#wordlistSelections input') as NodeListOf<HTMLInputElement>;
+    let added = true;
+    let word = wordText.value.trim();
+    const subCase = substitutionCase.checked ? 1 : 0;
+    const sub = subCase > 0 ? substitutionText.value.trim() : substitutionText.value.trim().toLowerCase();
 
     if (Constants.MATCH_METHODS[selectedMatchMethod.value] !== Constants.MATCH_METHODS.REGEX) {
       word = word.toLowerCase();
@@ -1303,6 +1308,7 @@ export default class OptionPage {
       wordlistSelectionsInput.forEach((wordlist, index) => { if (wordlist.checked) { lists.push(index + 1); } });
 
       const wordOptions: WordOptions = {
+        case: subCase,
         lists: lists,
         matchMethod: Constants.MATCH_METHODS[selectedMatchMethod.value],
         repeat: wordMatchRepeated.checked,

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -189,9 +189,10 @@ export default class OptionPage {
     const cellRemoveRow = row.insertCell(0);
     const cellWord = row.insertCell(1);
     const cellSub = row.insertCell(2);
-    const cellMatchMethod = row.insertCell(3);
-    const cellRepeat = row.insertCell(4);
-    const cellSeparators = row.insertCell(5);
+    const cellSubCase = row.insertCell(3);
+    const cellMatchMethod = row.insertCell(4);
+    const cellRepeat = row.insertCell(5);
+    const cellSeparators = row.insertCell(6);
 
     const removeButton = document.createElement('button');
     removeButton.textContent = 'X';
@@ -208,6 +209,12 @@ export default class OptionPage {
     subInput.type = 'text';
     cellSub.appendChild(subInput);
     subInput.value = data.sub;
+
+    const subCaseInput = document.createElement('input');
+    subCaseInput.type = 'checkbox';
+    subCaseInput.name = 'subCase';
+    subCaseInput.checked = numberToBoolean(data.case);
+    cellSubCase.appendChild(subCaseInput);
 
     const matchMethodSelect = document.createElement('select');
     Constants.orderedArray(Constants.MATCH_METHODS).forEach((matchMethod, index) => {
@@ -233,8 +240,9 @@ export default class OptionPage {
     separatorsInput.checked =  numberToBoolean(data.separators);
     cellSeparators.appendChild(separatorsInput);
 
+    const existingCellCount = row.cells.length;
     this.cfg.wordlists.forEach((wordlist, index) => {
-      const cell = row.insertCell(index + 6);
+      const cell = row.insertCell(index + existingCellCount);
       const wordlistInput = document.createElement('input');
       wordlistInput.type = 'checkbox';
       wordlistInput.name = 'wordlists';
@@ -303,10 +311,11 @@ export default class OptionPage {
       const name = (cells[1].querySelector('input') as HTMLInputElement).value;
       if (name != '') {
         const wordOptions: WordOptions = {
+          case: booleanToNumber((cells[3].querySelector('input') as HTMLInputElement).checked),
           lists: lists,
-          matchMethod: (cells[3].querySelector('select') as HTMLSelectElement).selectedIndex,
-          repeat: booleanToNumber((cells[4].querySelector('input') as HTMLInputElement).checked),
-          separators: booleanToNumber((cells[5].querySelector('input') as HTMLInputElement).checked),
+          matchMethod: (cells[4].querySelector('select') as HTMLSelectElement).selectedIndex,
+          repeat: booleanToNumber((cells[5].querySelector('input') as HTMLInputElement).checked),
+          separators: booleanToNumber((cells[6].querySelector('input') as HTMLInputElement).checked),
           sub: (cells[2].querySelector('input') as HTMLInputElement).value
         };
         const success = this.cfg.addWord(name, wordOptions);
@@ -357,7 +366,7 @@ export default class OptionPage {
     removeCell.appendChild(removeSpan);
     row.appendChild(removeCell);
 
-    const normalHeaders = ['Word', 'Substitution', 'Match Method', 'Repeated', 'Separators'];
+    const normalHeaders = ['Word', 'Substitution', 'Substitution Case', 'Match Method', 'Repeated', 'Separators'];
     normalHeaders.forEach((item) => {
       const cell = document.createElement('th');
       const cellSpan = document.createElement('span');

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -1287,8 +1287,9 @@ export default class OptionPage {
     let word = wordText.value.trim();
     const subCase = substitutionCase.checked ? 1 : 0;
     const sub = subCase > 0 ? substitutionText.value.trim() : substitutionText.value.trim().toLowerCase();
+    const matchMethod = Constants.MATCH_METHODS[selectedMatchMethod.value];
 
-    if (Constants.MATCH_METHODS[selectedMatchMethod.value] !== Constants.MATCH_METHODS.REGEX) {
+    if (matchMethod !== Constants.MATCH_METHODS.REGEX) {
       word = word.toLowerCase();
     }
 
@@ -1310,10 +1311,10 @@ export default class OptionPage {
       const wordOptions: WordOptions = {
         case: subCase,
         lists: lists,
-        matchMethod: Constants.MATCH_METHODS[selectedMatchMethod.value],
+        matchMethod: matchMethod,
         repeat: wordMatchRepeated.checked,
         separators: wordMatchSeparators.checked,
-        sub: sub
+        sub: sub,
       };
 
       // Check for endless substitution loop

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -887,7 +887,7 @@ export default class OptionPage {
       wordMatchRepeated.checked = numberToBoolean(wordCfg.repeat);
       wordMatchSeparators.checked = numberToBoolean(wordCfg.separators === undefined ? this.cfg.defaultWordSeparators : wordCfg.separators);
       substitutionText.value = wordCfg.sub;
-      substitutionCase.checked = wordCfg.case > 0;
+      substitutionCase.checked = numberToBoolean(wordCfg.case);
       wordlistSelections.forEach((wordlist, index) => {
         wordlist.checked = wordCfg.lists.includes(index + 1);
       });
@@ -1285,8 +1285,8 @@ export default class OptionPage {
     const wordlistSelectionsInput = document.querySelectorAll('div#wordlistSelections input') as NodeListOf<HTMLInputElement>;
     let added = true;
     let word = wordText.value.trim();
-    const subCase = substitutionCase.checked ? 1 : 0;
-    const sub = subCase > 0 ? substitutionText.value.trim() : substitutionText.value.trim().toLowerCase();
+    const subCase = booleanToNumber(substitutionCase.checked);
+    const sub = numberToBoolean(subCase) ? substitutionText.value.trim() : substitutionText.value.trim().toLowerCase();
     const matchMethod = Constants.MATCH_METHODS[selectedMatchMethod.value];
 
     if (matchMethod !== Constants.MATCH_METHODS.REGEX) {

--- a/src/script/webAudio.ts
+++ b/src/script/webAudio.ts
@@ -444,7 +444,13 @@ export default class WebAudio {
       // Issue 251: YouTube is now filtering words out of auto-generated captions/subtitles
       const youTubeAutoCensor = '[ __ ]';
       const lists = this.wordlistId === Constants.ALL_WORDS_WORDLIST_ID ? [] : [this.wordlistId];
-      const youTubeAutoCensorOptions: WordOptions = { lists: lists, matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: false, separators: false, sub: '' };
+      const youTubeAutoCensorOptions: WordOptions = {
+        lists: lists,
+        matchMethod: Constants.MATCH_METHODS.PARTIAL,
+        repeat: Constants.FALSE,
+        separators: Constants.FALSE,
+        sub: '',
+      };
       this.filter.cfg.addWord(youTubeAutoCensor, youTubeAutoCensorOptions);
 
       // Setup rule for YouTube Auto Subs

--- a/src/script/webConfig.ts
+++ b/src/script/webConfig.ts
@@ -64,7 +64,7 @@ export default class WebConfig extends Config {
   }
 
   static chromeStorageAvailable(): boolean {
-    return !!(chrome && chrome.storage && (chrome.storage.sync || chrome.storage.local));
+    return !!(chrome && chrome.storage && chrome.storage.sync && chrome.storage.local);
   }
 
   // Combine all ._[prop]* into .[prop]

--- a/src/static/optionPage.css
+++ b/src/static/optionPage.css
@@ -90,6 +90,10 @@ div#wordsPage #wordlistSelections label input {
   margin-right: 5px;
 }
 
+div#wordsPage input#substitutionText {
+  display: inline;
+}
+
 /* Audio */
 .updateYouTubeAutoLimits {
   width: 70px;

--- a/src/static/optionPage.html
+++ b/src/static/optionPage.html
@@ -183,6 +183,7 @@
     <div id="wordSubstitution" class="w3-hide">
       <h4 class="sectionHeader">Substitution</h4>
       <input id="substitutionText" class="w3-input w3-border small"/>
+      <label><input id="substitutionCase" type="checkbox" class="w3-check">  Case-sensitive</label>
     </div>
 
     <div id="wordMatchMethod">

--- a/test/dataMigration.spec.js
+++ b/test/dataMigration.spec.js
@@ -4,6 +4,7 @@ import DataMigration from './built/dataMigration';
 import WebConfig from './built/webConfig';
 
 describe('DataMigration', function() {
+  // 2.7.0
   describe('addWordlistsToWords()', function() {
     it('should add wordlist to all words', function() {
       const cfg = {
@@ -21,6 +22,7 @@ describe('DataMigration', function() {
     });
   });
 
+  // 2.7.0
   describe('removeGlobalMatchMethod()', function() {
     it('should remove global match method and adjust RegExp method', function() {
       const data = {
@@ -44,6 +46,7 @@ describe('DataMigration', function() {
     });
   });
 
+  // 2.7.0
   describe('removeOldDomainArrays()', function() {
     it('should migrate all old domain arrays', function() {
       const cfg = {
@@ -62,6 +65,43 @@ describe('DataMigration', function() {
       expect(cfg.domains['example.com'].enabled).to.be.true;
       expect(cfg.domains['test.org'].disabled).to.be.true;
       expect(cfg.domains['test.org'].adv).to.be.undefined;
+    });
+  });
+
+  // 2.20.0
+  describe('updateWordRepeatAndSeparatorDataTypes()', function() {
+    describe('convert repeat and separators to numbers', function() {
+      const data = {
+        words: {
+          'test': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: false, separators: false, sub: 'tset' },
+          'another': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, separators: true, sub: 'tset' },
+          'testWithList': { lists: [1, 3, 5], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, separators: false, sub: 'tset' },
+          'withoutRepeat': { lists: [1, 3, 5], matchMethod: Constants.MATCH_METHODS.EXACT, separators: true, sub: 'tset' },
+        }
+      };
+      const cfg = new WebConfig(data);
+      const dataMigration = new DataMigration(cfg);
+      dataMigration.updateWordRepeatAndSeparatorDataTypes();
+
+      it('when both are false', function() {
+        expect(cfg.words['test'].repeat).to.equal(Constants.FALSE);
+        expect(cfg.words['test'].separators).to.equal(Constants.FALSE);
+      });
+
+      it('when both are false', function() {
+        expect(cfg.words['another'].repeat).to.equal(Constants.TRUE);
+        expect(cfg.words['another'].separators).to.equal(Constants.TRUE);
+      });
+
+      it('when repeat is true and separators is false', function() {
+        expect(cfg.words['testWithList'].repeat).to.equal(Constants.TRUE);
+        expect(cfg.words['testWithList'].separators).to.equal(Constants.FALSE);
+      });
+
+      it('when repeat is not present and separators is true', function() {
+        expect(cfg.words['withoutRepeat'].repeat).to.equal(Constants.FALSE);
+        expect(cfg.words['withoutRepeat'].separators).to.equal(Constants.TRUE);
+      });
     });
   });
 });

--- a/test/lib/config.spec.js
+++ b/test/lib/config.spec.js
@@ -67,10 +67,10 @@ describe('Config', function() {
     config.words = Object.assign({}, Config._defaultWords);
 
     it('should return the repeat option for a word', function() {
-      config.words['newWord'] = { matchMethod: config.defaultWordMatchMethod, repeat: true, words: [] };
-      expect(config.repeatForWord('newWord')).to.eql(true);
-      config.words['anotherNewWord'] = { matchMethod: config.defaultWordMatchMethod, repeat: false, words: [] };
-      expect(config.repeatForWord('anotherNewWord')).to.eql(false);
+      config.words['newWord'] = { matchMethod: config.defaultWordMatchMethod, repeat: Constants.TRUE, words: [] };
+      expect(config.repeatForWord('newWord')).to.eql(Constants.TRUE);
+      config.words['anotherNewWord'] = { matchMethod: config.defaultWordMatchMethod, repeat: Constants.FALSE, words: [] };
+      expect(config.repeatForWord('anotherNewWord')).to.eql(Constants.FALSE);
     });
 
     it('should return the default word repeat when not present on word', function() {

--- a/test/lib/config.spec.js
+++ b/test/lib/config.spec.js
@@ -32,7 +32,7 @@ describe('Config', function() {
     });
 
     it('should add a new word to the config with provided options', function() {
-      const wordOptions = { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, sub: 'Older-word' };
+      const wordOptions = { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, sub: 'Older-word' };
       expect(config.addWord('newer-word', wordOptions)).to.equal(true);
       expect(Object.keys(config.words)).to.include('newer-word');
       expect(config.words['newer-word'].matchMethod).to.equal(wordOptions.matchMethod);

--- a/test/lib/filter.spec.js
+++ b/test/lib/filter.spec.js
@@ -275,6 +275,62 @@ describe('Filter', () => {
           expect(filter.replaceText('Go out with a !Bang!')).to.equal('Go out with a !Bang!');
           expect(filter.replaceText('!ANOTHER! so cool!')).to.equal('$ZNOTHER# so cool!');
         });
+
+        describe('Words and phrases with both case sensitivities', () => {
+          const filter = new Filter;
+          filter.cfg = new Config({
+            words: {
+              'oneword': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, case: Constants.TRUE, sub: 'wOrD', lists: [] },
+              'pizza': { matchMethod: Constants.MATCH_METHODS.EXACT, sub: 'chocolate', lists: [] },
+              'pie': { matchMethod: Constants.MATCH_METHODS.EXACT, sub: 'ice cream', lists: [] },
+              'corn on the cob': { matchMethod: Constants.MATCH_METHODS.EXACT, sub: 'corn', lists: [] },
+              'a phrase too': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, case: Constants.TRUE, sub: 'mULTIPLE wORDS tOO', lists: [] },
+              "here's a little song i wrote": { matchMethod: Constants.MATCH_METHODS.EXACT, sub: 'my gift is my song', lists: [] },
+            }, filterMethod: Constants.FILTER_METHODS.SUBSTITUTE,
+            substitutionMark: false,
+            preserveCase: true,
+          });
+          filter.init();
+
+          it('Word with case sensitivity on', () => {
+            expect(filter.replaceText('What is the oneword?')).to.equal('What is the wOrD?');
+            expect(filter.replaceText('What is the oneword?')).to.equal('What is the wOrD?');
+          });
+
+          it('Word with case sensitivity off (preserveCase on)', () => {
+            expect(filter.replaceText('Pizza is the best!')).to.equal('Chocolate is the best!');
+          });
+
+          it('Word with case sensitivity off (preserveCase on)', () => {
+            expect(filter.replaceText('Pizza is the best!')).to.equal('Chocolate is the best!');
+          });
+
+          it('Phrase with case sensitivity on', () => {
+            expect(filter.replaceText('I can filter and capitalize A Phrase Too!')).to.equal('I can filter and capitalize mULTIPLE wORDS tOO!');
+            expect(filter.replaceText('I can filter and capitalize A Phraseeeee Too!')).to.equal('I can filter and capitalize mULTIPLE wORDS tOO!');
+          });
+
+          it('Phrase with case sensitivity off (preserveCase on)', () => {
+            expect(filter.replaceText("Here's A Little Song I Wrote, you might want to sing it note for note")).to.equal('My Gift Is My Song, you might want to sing it note for note');
+            expect(filter.replaceText("Here's a Little Song I Wrote, you might want to sing it note for note")).to.equal('My gift is my song, you might want to sing it note for note');
+            expect(filter.replaceText("here's a little song i wrote, you might want to sing it note for note")).to.equal('my gift is my song, you might want to sing it note for note');
+            expect(filter.replaceText("HERE'S A LITTLE SONG I WROTE, you might want to sing it note for note")).to.equal('MY GIFT IS MY SONG, you might want to sing it note for note');
+          });
+
+          it('Word to substitution phrase with case sensitivity off (preserveCase on)', () => {
+            expect(filter.replaceText('Do you like to eat pie?')).to.equal('Do you like to eat ice cream?');
+            expect(filter.replaceText('Do you like to eat Pie?')).to.equal('Do you like to eat Ice Cream?');
+            expect(filter.replaceText('Do you like to eat PIE?')).to.equal('Do you like to eat ICE CREAM?');
+          });
+
+          it('Phrase to substitution word with case sensitivity off (preserveCase on)', () => {
+            expect(filter.replaceText('Do you like to eat corn on the cob?')).to.equal('Do you like to eat corn?');
+            expect(filter.replaceText('Do you like to eat corn On The Cob?')).to.equal('Do you like to eat corn?');
+            expect(filter.replaceText('Do you like to eat Corn on the cob?')).to.equal('Do you like to eat Corn?');
+            expect(filter.replaceText('Do you like to eat Corn On The Cob?')).to.equal('Do you like to eat Corn?');
+            expect(filter.replaceText('Do you like to eat CORN ON THE COB?')).to.equal('Do you like to eat CORN?');
+          });
+        });
       });
 
       describe('Partial', () => {

--- a/test/lib/filter.spec.js
+++ b/test/lib/filter.spec.js
@@ -4,10 +4,10 @@ import Config from '../built/lib/config';
 import Filter from '../built/lib/filter';
 
 const testWords = {
-  'example': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, sub: 'demo', lists: [] },
-  'placeholder': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: false, sub: 'variable', lists: [] },
-  'sample': { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: false, sub: 'piece', lists: [] },
-  'word': { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: true, sub: 'idea', lists: [] }
+  'example': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, sub: 'demo', lists: [] },
+  'placeholder': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.FALSE, sub: 'variable', lists: [] },
+  'sample': { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.FALSE, sub: 'piece', lists: [] },
+  'word': { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: Constants.TRUE, sub: 'idea', lists: [] },
 };
 
 describe('Filter', () => {
@@ -28,7 +28,7 @@ describe('Filter', () => {
       filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FILTER_METHODS.CENSOR });
       filter.cfg = new Config({
         filterMethod: Constants.FILTER_METHODS.CENSOR,
-        words: Object.assign({}, testWords, { '^regexp.*?$': { matchMethod: Constants.MATCH_METHODS.REGEX, repeat: false, sub: 'substitute' } })
+        words: Object.assign({}, testWords, { '^regexp.*?$': { matchMethod: Constants.MATCH_METHODS.REGEX, repeat: Constants.FALSE, sub: 'substitute' } })
       });
       filter.init();
       expect(filter.wordlists[filter.wordlistId].regExps).to.eql([
@@ -64,13 +64,13 @@ describe('Filter', () => {
     it('should rebuild all wordlists', () => {
       const filter = new Filter;
       filter.cfg = new Config({ words: Object.assign({}, testWords) });
-      filter.cfg.words['book'] = { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: true, sub: 'journal', lists: [1] };
+      filter.cfg.words['book'] = { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: Constants.TRUE, sub: 'journal', lists: [1] };
       filter.init();
       expect(Object.keys(filter.wordlists).length).to.equal(1);
       filter.buildWordlist(1);
       expect(Object.keys(filter.wordlists).length).to.equal(2);
       expect(Object.keys(filter.wordlists[1].all).length).to.equal(1);
-      filter.cfg.words['food'] = { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: true, sub: 'sustenance', lists: [1] };
+      filter.cfg.words['food'] = { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: Constants.TRUE, sub: 'sustenance', lists: [1] };
       expect(Object.keys(filter.wordlists[0].all).length).to.equal(5);
       expect(Object.keys(filter.wordlists[1].all).length).to.equal(1);
       filter.rebuildWordlists();
@@ -110,7 +110,7 @@ describe('Filter', () => {
 
         it('With separators', () => {
           const filter = new Filter;
-          const words = { pizza: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: true } };
+          const words = { pizza: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.TRUE } };
           filter.cfg = new Config({ words: words, filterMethod: Constants.FILTER_METHODS.CENSOR, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: true });
           filter.init();
           expect(filter.replaceText('I love to eat P-I-Z-___Z---A!')).to.equal('I love to eat P************A!');
@@ -149,7 +149,7 @@ describe('Filter', () => {
         it('Should filter a RegExp and fixed length (5) with preserveLast', () => {
           const filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FILTER_METHODS.CENSOR, censorCharacter: '_', censorFixedLength: 5, preserveFirst: false, preserveLast: true });
-          filter.cfg.words['^The'] = { matchMethod: Constants.MATCH_METHODS.REGEX, repeat: false, sub: 'substitute' };
+          filter.cfg.words['^The'] = { matchMethod: Constants.MATCH_METHODS.REGEX, repeat: Constants.FALSE, sub: 'substitute' };
           filter.init();
           expect(filter.replaceText('The best things are always the best.')).to.equal('____e best things are always the best.');
         });
@@ -158,7 +158,7 @@ describe('Filter', () => {
       describe('whitelist', () => {
         it('case-sensitive exact match', () => {
           const filter = new Filter;
-          const words = { master: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, sub: 'padawan' } };
+          const words = { master: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, sub: 'padawan' } };
           filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FILTER_METHODS.CENSOR, wordWhitelist: ['Master'] });
           filter.init();
           expect(filter.replaceText('Can the master outsmart the Master?')).to.equal('Can the m***** outsmart the Master?');
@@ -167,7 +167,7 @@ describe('Filter', () => {
 
         it('case-sensitive partial match', () => {
           const filter = new Filter;
-          const words = { more: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true } };
+          const words = { more: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE } };
           filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FILTER_METHODS.CENSOR, wordWhitelist: ['smore'] });
           filter.init();
           expect(filter.replaceText('Would you like smore smores?')).to.equal('Would you like smore sm***s?');
@@ -177,8 +177,8 @@ describe('Filter', () => {
         it('case-insensitive exact match', () => {
           const filter = new Filter;
           const words = {
-            master: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, sub: 'padawan' },
-            the: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, sub: 'teh' }
+            master: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, sub: 'padawan' },
+            the: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, sub: 'teh' }
           };
           filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FILTER_METHODS.CENSOR, iWordWhitelist: ['master'] });
           filter.init();
@@ -188,7 +188,7 @@ describe('Filter', () => {
 
         it('case-sinsensitive partial match', () => {
           const filter = new Filter;
-          const words = { more: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true } };
+          const words = { more: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE } };
           filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FILTER_METHODS.CENSOR, iWordWhitelist: ['smore'] });
           filter.init();
           expect(filter.replaceText('Would you like sMorE smores?')).to.equal('Would you like sMorE sm***s?');
@@ -200,7 +200,7 @@ describe('Filter', () => {
         it('preserveFirst', () => {
           const filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FILTER_METHODS.CENSOR, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: false });
-          filter.cfg.words['врата'] = { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, sub: 'door' };
+          filter.cfg.words['врата'] = { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, sub: 'door' };
           filter.init();
           expect(filter.replaceText('this even works on unicode words like врата, cool huh?')).to.equal('this even works on unicode w**** like в****, cool huh?');
         });
@@ -208,7 +208,7 @@ describe('Filter', () => {
         it('preserveFirst and preserveLast', () => {
           const filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FILTER_METHODS.CENSOR, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: true });
-          filter.cfg.words['котка'] = { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, sub: 'cat' };
+          filter.cfg.words['котка'] = { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, sub: 'cat' };
           filter.init();
           expect(filter.replaceText('The коткаs in the hat')).to.equal('The к***аs in the hat');
         });
@@ -216,7 +216,7 @@ describe('Filter', () => {
         it('With (_) characters and preserveFirst', () => {
           const filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FILTER_METHODS.CENSOR, censorCharacter: '_', censorFixedLength: 0, preserveFirst: true, preserveLast: false });
-          filter.cfg.words['куче'] = { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: true, sub: 'dog' };
+          filter.cfg.words['куче'] = { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: Constants.TRUE, sub: 'dog' };
           filter.init();
           expect(filter.replaceText('The bigкучеs ran around the yard.')).to.equal('The b_______ ran around the yard.');
         });
@@ -224,7 +224,7 @@ describe('Filter', () => {
         it('With (*) characters', () => {
           const filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FILTER_METHODS.CENSOR, censorCharacter: '*', censorFixedLength: 0, preserveFirst: false, preserveLast: false });
-          filter.cfg.words['словен'] = { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: false };
+          filter.cfg.words['словен'] = { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: Constants.FALSE };
           filter.init();
           expect(filter.replaceText('За пределами Словении этнические словенцы компактно')).to.equal('За пределами ******** этнические ******** компактно');
         });
@@ -232,7 +232,7 @@ describe('Filter', () => {
         it('Should not filter a whitelisted word (partial match)', () => {
           const filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FILTER_METHODS.CENSOR, censorCharacter: '*', preserveFirst: false, preserveLast: false, wordWhitelist: ['словенцы'] });
-          filter.cfg.words['ловен'] = { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: false };
+          filter.cfg.words['ловен'] = { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.FALSE };
           filter.init();
           expect(filter.replaceText('За пределами Словении этнические словенцы компактно')).to.equal('За пределами С*****ии этнические словенцы компактно');
           expect(filter.counter).to.equal(1);
@@ -263,9 +263,9 @@ describe('Filter', () => {
             substitutionMark: false,
             preserveCase: true,
             words: {
-              'this!': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: false, sub: 'that!' },
-              '!bang': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, sub: '!poof' },
-              '!another!': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: false, sub: '$znother#' }
+              'this!': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.FALSE, sub: 'that!' },
+              '!bang': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, sub: '!poof' },
+              '!another!': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.FALSE, sub: '$znother#' }
             },
           });
           filter.init();
@@ -288,7 +288,7 @@ describe('Filter', () => {
         it('Default substitution not marked and preserveCase', () => {
           const filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), defaultSubstitution: 'censored', filterMethod: Constants.FILTER_METHODS.SUBSTITUTE, substitutionMark: false, preserveCase: true });
-          filter.cfg.words['this'] = { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, sub: '' };
+          filter.cfg.words['this'] = { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, sub: '' };
           filter.init();
           expect(filter.replaceText('This Sample is a pretty good sampler to sample.')).to.equal('Censored Piece is a pretty good piecer to piece.');
         });
@@ -313,7 +313,7 @@ describe('Filter', () => {
 
         it('Match separators', () => {
           const filter = new Filter;
-          const words = { pizza: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: true, sub: 'pie' } };
+          const words = { pizza: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.TRUE, sub: 'pie' } };
           filter.cfg = new Config({ words: words, filterMethod: Constants.FILTER_METHODS.SUBSTITUTE, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: true });
           filter.init();
           expect(filter.replaceText('I love to eat P-I-Z-Z-A!')).to.equal('I love to eat PIE!');
@@ -326,7 +326,7 @@ describe('Filter', () => {
         it('Should filter a RegExp with capture groups', () => {
           const filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FILTER_METHODS.SUBSTITUTE });
-          filter.cfg.words['c(a|u)t'] = { matchMethod: Constants.MATCH_METHODS.REGEX, repeat: false, sub: 'bit' };
+          filter.cfg.words['c(a|u)t'] = { matchMethod: Constants.MATCH_METHODS.REGEX, repeat: Constants.FALSE, sub: 'bit' };
           filter.init();
           expect(filter.replaceText('Have you ever been cut by a Cat?')).to.equal('Have you ever been bit by a Bit?');
         });
@@ -335,7 +335,7 @@ describe('Filter', () => {
       describe('whitelist', () => {
         it('case-sensitive exact match', () => {
           const filter = new Filter;
-          const words = { master: { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: true, sub: 'padawan' } };
+          const words = { master: { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: Constants.TRUE, sub: 'padawan' } };
           filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FILTER_METHODS.SUBSTITUTE, substitutionMark: false, preserveCase: true, wordWhitelist: ['Master'] });
           filter.init();
           expect(filter.replaceText('Can the master outsmart the Master?')).to.equal('Can the padawan outsmart the Master?');
@@ -345,8 +345,8 @@ describe('Filter', () => {
         it('case insensitive exact match', () => {
           const filter = new Filter;
           const words = {
-            master: { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, sub: 'padawan' },
-            the: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, sub: 'teh' }
+            master: { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, sub: 'padawan' },
+            the: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, sub: 'teh' }
           };
           filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FILTER_METHODS.SUBSTITUTE, iWordWhitelist: ['master'] });
           filter.init();
@@ -356,7 +356,7 @@ describe('Filter', () => {
 
         it('case insensitive partial match', () => {
           const filter = new Filter;
-          const words = { more: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, sub: 'less' } };
+          const words = { more: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, sub: 'less' } };
           filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FILTER_METHODS.SUBSTITUTE, iWordWhitelist: ['smore'] });
           filter.init();
           expect(filter.replaceText('Would you like sMorE smores?')).to.equal('Would you like sMorE slesss?');
@@ -368,7 +368,7 @@ describe('Filter', () => {
         it('Exact word with substitions marked and preserveCase with repeated characters', () => {
           const filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FILTER_METHODS.SUBSTITUTE, substitutionMark: true, preserveCase: true });
-          filter.cfg.words['врата'] = { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, sub: 'door' };
+          filter.cfg.words['врата'] = { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, sub: 'door' };
           filter.init();
           expect(filter.replaceText('this even works on unicode WORDS like Врата, cool huh?')).to.equal('this even works on unicode [IDEA] like [Door], cool huh?');
         });
@@ -388,7 +388,7 @@ describe('Filter', () => {
 
         it('Ending with punctuation', () => {
           const filter = new Filter;
-          filter.cfg = new Config({ filterMethod: Constants.FILTER_METHODS.REMOVE, words: { 'this!': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: false } } });
+          filter.cfg = new Config({ filterMethod: Constants.FILTER_METHODS.REMOVE, words: { 'this!': { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.FALSE } } });
           filter.init();
           expect(filter.replaceText('I love This! Do you?')).to.equal('I love Do you?');
           expect(filter.replaceText('I love this!')).to.equal('I love');
@@ -396,7 +396,7 @@ describe('Filter', () => {
 
         it('With separators', () => {
           const filter = new Filter;
-          const words = { pizza: { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, separators: true } };
+          const words = { pizza: { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, separators: Constants.TRUE } };
           filter.cfg = new Config({ words: words, filterMethod: Constants.FILTER_METHODS.REMOVE, censorCharacter: '*', censorFixedLength: 0, preserveFirst: true, preserveLast: true });
           filter.init();
           expect(filter.replaceText('I love to eat PPPPPP-I-----ZZZZZZZZZZZ__A!')).to.equal('I love to eat!');
@@ -415,7 +415,7 @@ describe('Filter', () => {
 
         it('Ending with punctuation', () => {
           const filter = new Filter;
-          filter.cfg = new Config({ filterMethod: Constants.FILTER_METHODS.REMOVE, words: { 'this!': { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: false } } });
+          filter.cfg = new Config({ filterMethod: Constants.FILTER_METHODS.REMOVE, words: { 'this!': { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.FALSE } } });
           filter.init();
           expect(filter.replaceText('I love allthis! Do you?')).to.equal('I love Do you?');
           expect(filter.replaceText('I love this! Do you?')).to.equal('I love Do you?');
@@ -425,7 +425,7 @@ describe('Filter', () => {
       it('Should filter a RegExp', () => {
         const filter = new Filter;
         filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FILTER_METHODS.REMOVE });
-        filter.cfg.words['this and everything after.*$'] = { matchMethod: Constants.MATCH_METHODS.REGEX, repeat: false, sub: 'substitute' };
+        filter.cfg.words['this and everything after.*$'] = { matchMethod: Constants.MATCH_METHODS.REGEX, repeat: Constants.FALSE, sub: 'substitute' };
         filter.init();
         expect(filter.replaceText('Have you ever done this and everything after it?')).to.equal('Have you ever done ');
       });
@@ -433,7 +433,7 @@ describe('Filter', () => {
       describe('whitelist', () => {
         it('case-sensitive exact match', () => {
           const filter = new Filter;
-          const words = { master: { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, sub: 'padawan' } };
+          const words = { master: { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, sub: 'padawan' } };
           filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FILTER_METHODS.REMOVE, wordWhitelist: ['Master'] });
           filter.init();
           expect(filter.replaceText('Can the master outsmart the Master?')).to.equal('Can the outsmart the Master?');
@@ -442,7 +442,7 @@ describe('Filter', () => {
 
         it('case-sensitive partial match', () => {
           const filter = new Filter;
-          const words = { more: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true } };
+          const words = { more: { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE } };
           filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FILTER_METHODS.REMOVE, wordWhitelist: ['smores'] });
           filter.init();
           expect(filter.replaceText('Would you like smore smores?')).to.equal('Would you like smores?');
@@ -451,7 +451,7 @@ describe('Filter', () => {
 
         it('case-insensitive exact match)', () => {
           const filter = new Filter;
-          const words = { pie: { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, sub: 'cake' } };
+          const words = { pie: { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, sub: 'cake' } };
           filter.cfg = new Config({ words: Object.assign({}, words), filterMethod: Constants.FILTER_METHODS.REMOVE, iWordWhitelist: ['pie'] });
           filter.init();
           expect(filter.replaceText('Apple pie is the best PIE!')).to.equal('Apple pie is the best PIE!');
@@ -463,7 +463,7 @@ describe('Filter', () => {
         it('Exact word', () => {
           const filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FILTER_METHODS.REMOVE });
-          filter.cfg.words['врата'] = { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, sub: 'door' };
+          filter.cfg.words['врата'] = { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, sub: 'door' };
           filter.init();
           expect(filter.replaceText('This even works on врата. cool huh?')).to.equal('This even works on. cool huh?');
           expect(filter.replaceText('This even works on врата, cool huh?')).to.equal('This even works on, cool huh?');
@@ -473,7 +473,7 @@ describe('Filter', () => {
         it('Partial word', () => {
           const filter = new Filter;
           filter.cfg = new Config({ words: Object.assign({}, testWords), filterMethod: Constants.FILTER_METHODS.REMOVE });
-          filter.cfg.words['врата'] = { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, sub: 'door' };
+          filter.cfg.words['врата'] = { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, sub: 'door' };
           filter.init();
           expect(filter.replaceText('This even works on with-врата. Cool huh?')).to.equal('This even works on. Cool huh?');
           expect(filter.replaceText('The вратаs in the hat')).to.equal('The in the hat');

--- a/test/lib/helper.spec.js
+++ b/test/lib/helper.spec.js
@@ -1,9 +1,19 @@
 import { expect } from 'chai';
-import { formatNumber, getVersion, hmsToSeconds, isVersionOlder, removeFromArray, secondsToHMS } from '../built/lib/helper';
+import Constants from '../built/lib/constants';
+import { booleanToNumber, formatNumber, getVersion, hmsToSeconds, isVersionOlder, numberToBoolean, removeFromArray, secondsToHMS } from '../built/lib/helper';
 
 const array = ['a', 'needle', 'in', 'a', 'large', 'haystack'];
 
 describe('Helper', function() {
+  describe('booleanToNumber()', function() {
+    it('Return a number from a boolean', function() {
+      expect(booleanToNumber(true)).to.eql(Constants.TRUE);
+      expect(booleanToNumber(false)).to.eql(Constants.FALSE);
+      expect(booleanToNumber(undefined)).to.eql(Constants.FALSE);
+      expect(booleanToNumber(null)).to.eql(Constants.FALSE);
+    });
+  });
+
   describe('formatNumber()', function() {
     it('Format numbers for counter display', function() {
       expect(formatNumber(999)).to.eql('999');
@@ -90,6 +100,16 @@ describe('Helper', function() {
       version = getVersion('1.5.11');
       minimum = getVersion('1.5.10');
       expect(isVersionOlder(version, minimum)).to.equal(false);
+    });
+  });
+
+  describe('numberToBoolean()', function() {
+    it('Return a boolean from a number', function() {
+      expect(numberToBoolean(Constants.FALSE)).to.eql(false);
+      expect(numberToBoolean(Constants.TRUE)).to.eql(true);
+      expect(numberToBoolean(5)).to.eql(true);
+      expect(numberToBoolean(undefined)).to.eql(false);
+      expect(numberToBoolean(null)).to.eql(false);
     });
   });
 

--- a/test/lib/word.spec.js
+++ b/test/lib/word.spec.js
@@ -12,7 +12,7 @@ describe('Word', function() {
       });
 
       it('should build RegExp with matchRepeated', function() {
-        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true }, Config._defaults);
+        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE }, Config._defaults);
         expect(word.regExp).to.eql(/\bw+o+r+d+\b/gi);
       });
 
@@ -29,7 +29,7 @@ describe('Word', function() {
       });
 
       it('should build RegExp with matchSeparators and matchRepeated', function() {
-        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, separators: true }, Config._defaults);
+        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, separators: Constants.TRUE }, Config._defaults);
         expect(word.regExp).to.eql(/\bw+[-_ ]*o+[-_ ]*r+[-_ ]*d+\b/gi);
       });
 
@@ -44,7 +44,7 @@ describe('Word', function() {
         });
 
         it('should use workaround for UTF word boundaries with matchRepeated', function() {
-          const word = new Word('врата', { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true }, Config._defaults);
+          const word = new Word('врата', { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]+)(в+р+а+т+а+)([\\s.,\'"+!?|-]+|$)', 'giu')
@@ -60,17 +60,17 @@ describe('Word', function() {
       });
 
       it('should build RegExp with matchRepeated', function() {
-        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true }, Config._defaults);
+        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE }, Config._defaults);
         expect(word.regExp).to.eql(/w+o+r+d+/gi);
       });
 
       it('should build RegExp with matchSeparators', function() {
-        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.PARTIAL, separators: true }, Config._defaults);
+        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.PARTIAL, separators: Constants.TRUE }, Config._defaults);
         expect(word.regExp).to.eql(/w[-_ ]*o[-_ ]*r[-_ ]*d/gi);
       });
 
       it('should build RegExp with matchSeparators and matchRepeated', function() {
-        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true, separators: true }, Config._defaults);
+        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE, separators: Constants.TRUE }, Config._defaults);
         expect(word.regExp).to.eql(/w+[-_ ]*o+[-_ ]*r+[-_ ]*d+/gi);
       });
     });
@@ -82,7 +82,7 @@ describe('Word', function() {
       });
 
       it('should build RegExp with matchRepeated', function() {
-        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, _filterMethod: Constants.FILTER_METHODS.REMOVE }, Config._defaults);
+        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, _filterMethod: Constants.FILTER_METHODS.REMOVE }, Config._defaults);
         expect(word.regExp).to.eql(/\s?\bw+o+r+d+\b\s?/gi);
       });
 
@@ -102,7 +102,7 @@ describe('Word', function() {
         });
 
         it('should build RegExp with matchRepeated', function() {
-          const word = new Word('куче', { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, _filterMethod: Constants.FILTER_METHODS.REMOVE }, Config._defaults);
+          const word = new Word('куче', { matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, _filterMethod: Constants.FILTER_METHODS.REMOVE }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-])(к+у+ч+е+)([\\s.,\'"+!?|-]|$)', 'giu')
@@ -118,7 +118,7 @@ describe('Word', function() {
       });
 
       it('should build RegExp with matchRepeated', function() {
-        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true }, Object.assign(Config._defaults, { filterMethod: Constants.FILTER_METHODS.REMOVE }));
+        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE }, Object.assign(Config._defaults, { filterMethod: Constants.FILTER_METHODS.REMOVE }));
         expect(word.regExp).to.eql(/\s?\b[\w-]*w+o+r+d+[\w-]*\b\s?/gi);
       });
 
@@ -138,7 +138,7 @@ describe('Word', function() {
         });
 
         it('should build RegExp with matchRepeated', function() {
-          const word = new Word('куче', { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: true }, Object.assign(Config._defaults, { filterMethod: Constants.FILTER_METHODS.REMOVE }));
+          const word = new Word('куче', { matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.TRUE }, Object.assign(Config._defaults, { filterMethod: Constants.FILTER_METHODS.REMOVE }));
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]?)([\\w-]*к+у+ч+е+[\\w-]*)([\\s.,\'"+!?|-]?|$)', 'giu')
@@ -154,7 +154,7 @@ describe('Word', function() {
       });
 
       it('should build RegExp with matchRepeated', function() {
-        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: true }, Config._defaults);
+        const word = new Word('word', { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: Constants.TRUE }, Config._defaults);
         expect(word.regExp).to.eql(/\b[\w-]*w+o+r+d+[\w-]*\b/gi);
       });
 
@@ -174,7 +174,7 @@ describe('Word', function() {
         });
 
         it('should build RegExp with matchRepeated', function() {
-          const word = new Word('куче', { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: true }, Config._defaults);
+          const word = new Word('куче', { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: Constants.TRUE }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]*)([\\S]*к+у+ч+е+[\\S]*)([\\s.,\'"+!?|-]*|$)', 'giu')
@@ -182,7 +182,7 @@ describe('Word', function() {
         });
 
         it('should build RegExp with matchRepeated and matchSeparators', function() {
-          const word = new Word('куче', { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: true, separators: true }, Config._defaults);
+          const word = new Word('куче', { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: Constants.TRUE, separators: Constants.TRUE }, Config._defaults);
           expect(word.unicode).to.eql(true);
           expect(word.regExp).to.eql(
             new RegExp('(^|[\\s.,\'"+!?|-]*)([\\S]*к+[-_ ]*у+[-_ ]*ч+[-_ ]*е+[\\S]*)([\\s.,\'"+!?|-]*|$)', 'giu')
@@ -216,6 +216,7 @@ describe('Word', function() {
     describe('capitalizeEachWord()', function() {
       it('should return a string with the first character of each word capitalized', function() {
         expect(Word.capitalizeEachWord('live long and prosper')).to.equal('Live Long And Prosper');
+        expect(Word.capitalizeEachWord('cool')).to.equal('Cool');
       });
 
       it('should handle a phrase with repeated words', function() {
@@ -240,6 +241,7 @@ describe('Word', function() {
     describe('eachWordCapitalized()', function() {
       it('should return true when only the first character of each word is capitalized', function() {
         expect(Word.eachWordCapitalized('Upper Limit')).to.equal(true);
+        expect(Word.eachWordCapitalized('Upper')).to.equal(true);
       });
 
       it('should return false when each word does not start with a capital letter', function() {
@@ -271,7 +273,7 @@ describe('Word', function() {
 
     it('should use provided matchMethod (Exact) and fill in defaults', function() {
       const cfg = Object.assign({}, Config._defaults, { defaultWordMatchMethod: Constants.MATCH_METHODS.WHOLE });
-      const options = { lists: [1, 5], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true };
+      const options = { lists: [1, 5], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE };
       const word = new Word('again', options, cfg);
       expect(word.matchMethod).to.eql(options.matchMethod);
       expect(word.matchRepeated).to.eql(options.repeat);
@@ -281,7 +283,7 @@ describe('Word', function() {
 
     it('should use provided matchMethod (Whole) and fill in defaults', function() {
       const cfg = Config._defaults;
-      const options = { matchMethod: Constants.MATCH_METHODS.WHOLE, separators: true };
+      const options = { matchMethod: Constants.MATCH_METHODS.WHOLE, separators: Constants.TRUE };
       const word = new Word('testing', options, cfg);
       expect(word.matchMethod).to.eql(options.matchMethod);
       expect(word.matchRepeated).to.eql(cfg.defaultWordRepeat);

--- a/test/lib/word.spec.js
+++ b/test/lib/word.spec.js
@@ -212,23 +212,23 @@ describe('Word', function() {
     });
   });
 
-  describe('capitalized()', function() {
-    it('should return true when word is capitalized', function() {
-      expect(Word.capitalized('Upper')).to.equal(true);
+  describe('firstCapitalized()', function() {
+    it('should return true when only the first character of the word is capitalized', function() {
+      expect(Word.firstCapitalized('Upper')).to.equal(true);
     });
 
-    it('should return false when word is not capitalized', function() {
-      expect(Word.capitalized('upper')).to.equal(false);
+    it('should return false when word does not start with a capital letter', function() {
+      expect(Word.firstCapitalized('upper')).to.equal(false);
     });
   });
 
-  describe('capitalize()', function() {
-    it('should return a capitalized string', function() {
-      expect(Word.capitalize('upper')).to.equal('Upper');
+  describe('capitalizeFirst()', function() {
+    it('should return a string with the first character capitalized', function() {
+      expect(Word.capitalizeFirst('upper')).to.equal('Upper');
     });
 
     it('should return a capitalized string when its already capitalized', function() {
-      expect(Word.capitalize('Upper')).to.equal('Upper');
+      expect(Word.capitalizeFirst('Upper')).to.equal('Upper');
     });
   });
 

--- a/test/lib/word.spec.js
+++ b/test/lib/word.spec.js
@@ -192,67 +192,69 @@ describe('Word', function() {
     });
   });
 
-  describe('allLowerCase()', function() {
-    it('should return true when all lowercase', function() {
-      expect(Word.allLowerCase('lower')).to.equal(true);
+  describe('Capitalization', () =>{
+    describe('allLowerCase()', function() {
+      it('should return true when all lowercase', function() {
+        expect(Word.allLowerCase('lower')).to.equal(true);
+      });
+
+      it('should return false when not all lowercase', function() {
+        expect(Word.allLowerCase('Lower')).to.equal(false);
+      });
     });
 
-    it('should return false when not all lowercase', function() {
-      expect(Word.allLowerCase('Lower')).to.equal(false);
-    });
-  });
+    describe('allUpperCase()', function() {
+      it('should return true when all uppercase', function() {
+        expect(Word.allUpperCase('UPPER')).to.equal(true);
+      });
 
-  describe('allUpperCase()', function() {
-    it('should return true when all uppercase', function() {
-      expect(Word.allUpperCase('UPPER')).to.equal(true);
-    });
-
-    it('should return false when not all uppercase', function() {
-      expect(Word.allUpperCase('upper')).to.equal(false);
-    });
-  });
-
-  describe('firstCapitalized()', function() {
-    it('should return true when only the first character of the word is capitalized', function() {
-      expect(Word.firstCapitalized('Upper')).to.equal(true);
+      it('should return false when not all uppercase', function() {
+        expect(Word.allUpperCase('upper')).to.equal(false);
+      });
     });
 
-    it('should return false when word does not start with a capital letter', function() {
-      expect(Word.firstCapitalized('upper')).to.equal(false);
-    });
-  });
+    describe('capitalizeEachWord()', function() {
+      it('should return a string with the first character of each word capitalized', function() {
+        expect(Word.capitalizeEachWord('live long and prosper')).to.equal('Live Long And Prosper');
+      });
 
-  describe('capitalizeFirst()', function() {
-    it('should return a string with the first character capitalized', function() {
-      expect(Word.capitalizeFirst('upper')).to.equal('Upper');
-    });
+      it('should handle a phrase with repeated words', function() {
+        expect(Word.capitalizeEachWord('the best in the world')).to.equal('The Best In The World');
+      });
 
-    it('should return a capitalized string when its already capitalized', function() {
-      expect(Word.capitalizeFirst('Upper')).to.equal('Upper');
-    });
-  });
-
-  describe('eachWordCapitalized()', function() {
-    it('should return true when only the first character of each word is capitalized', function() {
-      expect(Word.eachWordCapitalized('Upper Limit')).to.equal(true);
+      it('should return a capitalized string when its already capitalized', function() {
+        expect(Word.capitalizeEachWord('Upper Limit')).to.equal('Upper Limit');
+      });
     });
 
-    it('should return false when each word does not start with a capital letter', function() {
-      expect(Word.eachWordCapitalized('Upper limit')).to.equal(false);
-    });
-  });
+    describe('capitalizeFirst()', function() {
+      it('should return a string with the first character capitalized', function() {
+        expect(Word.capitalizeFirst('upper')).to.equal('Upper');
+      });
 
-  describe('capitalizeEachWord()', function() {
-    it('should return a string with the first character of each word capitalized', function() {
-      expect(Word.capitalizeEachWord('live long and prosper')).to.equal('Live Long And Prosper');
-    });
-
-    it('should handle a phrase with repeated words', function() {
-      expect(Word.capitalizeEachWord('the best in the world')).to.equal('The Best In The World');
+      it('should return a capitalized string when its already capitalized', function() {
+        expect(Word.capitalizeFirst('Upper')).to.equal('Upper');
+      });
     });
 
-    it('should return a capitalized string when its already capitalized', function() {
-      expect(Word.capitalizeEachWord('Upper Limit')).to.equal('Upper Limit');
+    describe('eachWordCapitalized()', function() {
+      it('should return true when only the first character of each word is capitalized', function() {
+        expect(Word.eachWordCapitalized('Upper Limit')).to.equal(true);
+      });
+
+      it('should return false when each word does not start with a capital letter', function() {
+        expect(Word.eachWordCapitalized('Upper limit')).to.equal(false);
+      });
+    });
+
+    describe('firstCapitalized()', function() {
+      it('should return true when only the first character of the word is capitalized', function() {
+        expect(Word.firstCapitalized('Upper')).to.equal(true);
+      });
+
+      it('should return false when word does not start with a capital letter', function() {
+        expect(Word.firstCapitalized('upper')).to.equal(false);
+      });
     });
   });
 

--- a/test/lib/word.spec.js
+++ b/test/lib/word.spec.js
@@ -232,6 +232,30 @@ describe('Word', function() {
     });
   });
 
+  describe('eachWordCapitalized()', function() {
+    it('should return true when only the first character of each word is capitalized', function() {
+      expect(Word.eachWordCapitalized('Upper Limit')).to.equal(true);
+    });
+
+    it('should return false when each word does not start with a capital letter', function() {
+      expect(Word.eachWordCapitalized('Upper limit')).to.equal(false);
+    });
+  });
+
+  describe('capitalizeEachWord()', function() {
+    it('should return a string with the first character of each word capitalized', function() {
+      expect(Word.capitalizeEachWord('live long and prosper')).to.equal('Live Long And Prosper');
+    });
+
+    it('should handle a phrase with repeated words', function() {
+      expect(Word.capitalizeEachWord('the best in the world')).to.equal('The Best In The World');
+    });
+
+    it('should return a capitalized string when its already capitalized', function() {
+      expect(Word.capitalizeEachWord('Upper Limit')).to.equal('Upper Limit');
+    });
+  });
+
   describe('constructor()', function() {
     it('should use all provided defaults', function() {
       const cfg = Object.assign({}, Config._defaults, { defaultWordMatchMethod: Constants.MATCH_METHODS.WHOLE });

--- a/test/lib/wordlist.spec.js
+++ b/test/lib/wordlist.spec.js
@@ -3,10 +3,10 @@ import Constants from '../built/lib/constants';
 import Wordlist from '../built/lib/wordlist';
 
 const testWords = {
-  'example': { lists: [1], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, sub: 'demo' },
-  'placeholder': { lists: [1, 2], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: false, sub: 'variable' },
-  'sample': { lists: [2], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: false, sub: 'piece' },
-  'word': { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: true, sub: 'idea' }
+  'example': { lists: [1], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, sub: 'demo' },
+  'placeholder': { lists: [1, 2], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.FALSE, sub: 'variable' },
+  'sample': { lists: [2], matchMethod: Constants.MATCH_METHODS.PARTIAL, repeat: Constants.FALSE, sub: 'piece' },
+  'word': { matchMethod: Constants.MATCH_METHODS.WHOLE, repeat: Constants.TRUE, sub: 'idea' }
 };
 
 describe('Wordlist', function() {

--- a/test/webConfig.spec.js
+++ b/test/webConfig.spec.js
@@ -26,7 +26,7 @@ describe('WebConfig', function() {
     it('should combine _words# data', function() {
       const config = new WebConfig(WebConfig._defaults);
       config._words0 = WebConfig._defaultWords;
-      config._words1 = { 'test': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: true, separators: false, sub: 'tset' } };
+      config._words1 = { 'test': { lists: [], matchMethod: Constants.MATCH_METHODS.EXACT, repeat: Constants.TRUE, separators: Constants.FALSE, sub: 'tset' } };
       config._splitContainerKeys = ['words'];
       expect(config.words).to.not.exist;
       const combinedKeys = WebConfig.combineData(config, 'words');


### PR DESCRIPTION
## ✨  New Features & Updates:
- d334308cad7fb2c9e3a82072a9f41aeaacf3a847 Allow case-sensitive substitutions (#200)
- 09775352657e897fe905b221a93a7a2df98c256a Preserve case for each substitute word in phrase

## 🐛 Bugs Fixed:
- 452a3902f368934cf9c82093e6198678df74767b `chromeStorageAvailable` check both local and sync

## 🔧 Development:
- 028f7f70c225f1984435578fee9ba93f93b5b9e5 Convert word repeat and separators to numbers
- Adding tests for new case-sensitive substitutions and update tests for word repeat and separators