### PR TITLE
Fix marking regex backreference

### DIFF
--- a/src/script/lib/config.ts
+++ b/src/script/lib/config.ts
@@ -97,7 +97,7 @@ export default class Config {
     if (Object.keys(this.words).includes(str)) {
       return false; // Already exists
     } else {
-      options.sub = options.case ? options.sub.trim() : options.sub.trim().toLowerCase();
+      options.sub = options.case == Constants.TRUE ? options.sub.trim() : options.sub.trim().toLowerCase();
       this.words[str] = options;
       return true;
     }

--- a/src/script/lib/filter.ts
+++ b/src/script/lib/filter.ts
@@ -144,7 +144,10 @@ export default class Filter {
 
             // Support backreferences for REGEX match method (only checks for 1 capture group)
             if (word.matchMethod == Constants.MATCH_METHODS.REGEX && captureGroups.length && word.sub.includes('\\1')) {
-              captureGroups.forEach((captureGroup, i) => { sub = sub.replace(`\\${i + 1}`, captureGroup); });
+              // Use captureGroup.toLowerCase() when not preserving case
+              captureGroups.forEach((captureGroup, i) => {
+                sub = sub.replace(`\\${i + 1}`, this.cfg.preserveCase ? captureGroup : captureGroup.toLowerCase());
+              });
 
               // Only return if something was substituted
               if (sub !== word.sub) {

--- a/src/script/lib/filter.ts
+++ b/src/script/lib/filter.ts
@@ -140,19 +140,15 @@ export default class Filter {
             const { word, string, match, matchStartIndex, captureGroups, internalCaptureGroups } = this.matchData(wordlist, index, originalMatch, args);
             if (this.checkWhitelist(match, string, matchStartIndex, word)) { return match; } // Check for whitelisted match
             if (statsType) { this.foundMatch(word, statsType); }
+            let sub = word.sub || this.cfg.defaultSubstitution;
 
             // Support backreferences for REGEX match method (only checks for 1 capture group)
             if (word.matchMethod == Constants.MATCH_METHODS.REGEX && captureGroups.length && word.sub.includes('\\1')) {
-              let sub = word.sub;
               captureGroups.forEach((captureGroup, i) => { sub = sub.replace(`\\${i + 1}`, captureGroup); });
               if (sub !== word.sub) {
                 // Only return if something was substituted
                 return sub;
-              }
             }
-
-            // Filter
-            let sub = word.sub || this.cfg.defaultSubstitution;
 
             // Make substitution match case of original match
             if (!word.case && this.cfg.preserveCase) {

--- a/src/script/lib/filter.ts
+++ b/src/script/lib/filter.ts
@@ -160,7 +160,7 @@ export default class Filter {
             }
 
             // Make substitution match case of original match
-            if (!word.case && this.cfg.preserveCase) {
+            if (word.case == Constants.FALSE && this.cfg.preserveCase) {
               if (Word.allUpperCase(match)) {
                 sub = sub.toUpperCase();
               } else if (Word.eachWordCapitalized(match)) {

--- a/src/script/lib/filter.ts
+++ b/src/script/lib/filter.ts
@@ -145,9 +145,15 @@ export default class Filter {
             // Support backreferences for REGEX match method (only checks for 1 capture group)
             if (word.matchMethod == Constants.MATCH_METHODS.REGEX && captureGroups.length && word.sub.includes('\\1')) {
               captureGroups.forEach((captureGroup, i) => { sub = sub.replace(`\\${i + 1}`, captureGroup); });
+
+              // Only return if something was substituted
               if (sub !== word.sub) {
-                // Only return if something was substituted
+                if (this.cfg.substitutionMark) {
+                  sub = '[' + sub + ']';
+                }
+
                 return sub;
+              }
             }
 
             // Make substitution match case of original match

--- a/src/script/lib/helper.ts
+++ b/src/script/lib/helper.ts
@@ -34,11 +34,11 @@ export function formatNumber(number: number): string {
   } else if (length <= 6) { // 1,000 - 999,999
     const n = (number/1000).toPrecision();
     const index = n.indexOf('.');
-    return ((index >= -1 && index <= 1) ? n.substr(0, 3) : n.substr(0, index)) + 'k';
+    return ((index >= -1 && index <= 1) ? n.slice(0, 3) : n.slice(0, index)) + 'k';
   } else if (length <= 9) { // 1,000,000 - 999,999,999
     const n = (number/1000000).toPrecision();
     const index = n.indexOf('.');
-    return ((index >= -1 && index <= 1) ? n.substr(0, 3) : n.substr(0, index)) + 'M';
+    return ((index >= -1 && index <= 1) ? n.slice(0, 3) : n.slice(0, index)) + 'M';
   } else { // >= 1,000,000,000
     return '1G+';
   }
@@ -212,7 +212,7 @@ export function removeFromArray(array: string[], element: string) {
 }
 
 export function secondsToHMS(seconds: number): string {
-  return new Date(seconds * 1000).toISOString().substr(11, 12);
+  return new Date(seconds * 1000).toISOString().slice(11, (11 + 12));
 }
 
 export function stringArray(data: string | string[]): string[] {

--- a/src/script/lib/word.ts
+++ b/src/script/lib/word.ts
@@ -38,7 +38,7 @@ export default class Word {
   }
 
   static capitalizeFirst(string: string): string {
-    return string.charAt(0).toUpperCase() + string.substr(1);
+    return string.charAt(0).toUpperCase() + string.slice(1);
   }
 
   static containsDoubleByte(str): boolean {

--- a/test/lib/filter.spec.js
+++ b/test/lib/filter.spec.js
@@ -407,6 +407,15 @@ describe('Filter', () => {
           expect(filter.replaceText('B')).to.equal('[you typed: B]');
         });
 
+        it('Should not preserveCase when false using backreferences in replace', () => {
+          const filter = new Filter;
+          filter.cfg = new Config({ filterMethod: Constants.FILTER_METHODS.SUBSTITUTE, preserveCase: false, words: {} });
+          filter.cfg.words['(a)'] = { matchMethod: Constants.MATCH_METHODS.REGEX, repeat: Constants.FALSE, sub: 'you typed: \\1' };
+          filter.cfg.words['(b)'] = { matchMethod: Constants.MATCH_METHODS.REGEX, repeat: Constants.FALSE, sub: 'you typed: \\1' };
+          filter.init();
+          expect(filter.replaceText('a')).to.equal('you typed: a');
+          expect(filter.replaceText('B')).to.equal('you typed: b');
+        });
       });
 
       describe('whitelist', () => {

--- a/test/lib/filter.spec.js
+++ b/test/lib/filter.spec.js
@@ -396,6 +396,17 @@ describe('Filter', () => {
           expect(filter.replaceText('Try not to pee John off.')).to.equal('Try not to tick John off.');
           expect(filter.replaceText('Try not to scare John off.')).to.equal('Try not to spook John off.');
         });
+
+        it('Should support substitutionMark with backreferences in replace', () => {
+          const filter = new Filter;
+          filter.cfg = new Config({ filterMethod: Constants.FILTER_METHODS.SUBSTITUTE, substitutionMark: Constants.TRUE, words: {} });
+          filter.cfg.words['(a)'] = { matchMethod: Constants.MATCH_METHODS.REGEX, repeat: Constants.FALSE, sub: 'you typed: \\1' };
+          filter.cfg.words['(b)'] = { matchMethod: Constants.MATCH_METHODS.REGEX, repeat: Constants.FALSE, sub: 'you typed: \\1' };
+          filter.init();
+          expect(filter.replaceText('a')).to.equal('[you typed: a]');
+          expect(filter.replaceText('B')).to.equal('[you typed: B]');
+        });
+
       });
 
       describe('whitelist', () => {


### PR DESCRIPTION
## 🐛 Bugs Fixed:
- a5b3daa88de7438c19e76567b3450aa3aec08aec Fix substitution mark for regex with backreferences (#391)
- a6a1f6002793e5d544fe87692e4ffdef78c9c540 Respect preserve case for regex with backreferences

## 🔧 Development:
- 3621ec12c5cd03a6d28fb50d3c8631336f06cdec Replace "deprecated" `substr()` with `slice()`