### PR TITLE
Customize Web Audio Sites for Build Targets

### DIFF
--- a/bin/prebuild.mjs
+++ b/bin/prebuild.mjs
@@ -34,6 +34,11 @@ function firefoxBuild() {
   data.target = 'firefox';
 }
 
+function iOSBuild() {
+  data.target = 'ios';
+  data.config.muteMethod = 2; // Constants.MUTE_METHODS.VIDEO_MUTE;
+}
+
 function main() {
   const argv = parseArgv(process.argv);
   if (argv.count >= 2 && argv.count <= 4) {
@@ -65,6 +70,9 @@ function main() {
         break;
       case '--firefox':
         firefoxBuild();
+        break;
+      case '--ios':
+        iOSBuild();
         break;
       case '--manifestV2':
         manifestV2Build();
@@ -109,6 +117,7 @@ function targetFromData() {
       return `--manifestV${data.manifestVersion}`;
     case 'bookmarklet':
     case 'firefox:':
+    case 'ios':
     case 'safari':
       return `--${data.target}`;
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/richardfrost/AdvancedProfanityFilter#readme",
   "scripts": {
     "build:firefox": "node bin/prebuild.mjs --firefox && npm run build",
+    "build:ios": "node bin/prebuild.mjs --ios && npm run build",
     "build:libs": "tsc -p ./src/script/lib/tsconfig.json",
     "build:safari": "node bin/prebuild.mjs --safari && npm run build",
     "build:static": "node bin/copy-static.mjs",
@@ -43,6 +44,7 @@
     "release:all": "npm run release:mv2 && npm run release:mv3 && npm run release:firefox",
     "release:build": "npm run build:static && webpack --config bin/webpack.config.js",
     "release:firefox": "npm run package:firefox",
+    "release:ios": "npm run clean && node bin/prebuild.mjs --release --ios && npm run release:build",
     "release:safari": "npm run clean && node bin/prebuild.mjs --release --safari && npm run release:build",
     "release:mv2": "npm run package:mv2",
     "release:mv3": "npm run package:mv3",

--- a/src/script/lib/constants.ts
+++ b/src/script/lib/constants.ts
@@ -7,6 +7,7 @@ export default class Constants {
   static readonly BUILD_TARGET_BOOKMARKLET = 'bookmarklet';
   static readonly BUILD_TARGET_CHROME = 'chrome';
   static readonly BUILD_TARGET_FIREFOX = 'firefox';
+  static readonly BUILD_TARGET_IOS = 'ios';
   static readonly BUILD_TARGET_SAFARI = 'safari';
   static readonly DOMAIN_MODES = { NORMAL: 0, ADVANCED: 1, DEEP: 2 };
   static readonly FALSE = 0;

--- a/src/script/lib/constants.ts
+++ b/src/script/lib/constants.ts
@@ -4,6 +4,10 @@ import { upperCaseFirst } from './helper';
 export default class Constants {
   // Named Constants
   static readonly ALL_WORDS_WORDLIST_ID = 0;
+  static readonly BUILD_TARGET_BOOKMARKLET = 'bookmarklet';
+  static readonly BUILD_TARGET_CHROME = 'chrome';
+  static readonly BUILD_TARGET_FIREFOX = 'firefox';
+  static readonly BUILD_TARGET_SAFARI = 'safari';
   static readonly DOMAIN_MODES = { NORMAL: 0, ADVANCED: 1, DEEP: 2 };
   static readonly FALSE = 0;
   static readonly FILTER_METHODS = { CENSOR: 0, SUBSTITUTE: 1, REMOVE: 2, OFF: 3 };

--- a/src/script/lib/globals.d.ts
+++ b/src/script/lib/globals.d.ts
@@ -64,6 +64,11 @@ interface BackgroundStorage {
   };
 }
 
+interface BuildTargetSites {
+  disabledSites: string[];
+  sites: AudioSites;
+}
+
 interface ConfirmModalSettings {
   backup?: boolean;
   content?: string;

--- a/src/script/lib/globals.d.ts
+++ b/src/script/lib/globals.d.ts
@@ -3,6 +3,7 @@ interface AudioRule {
   _dynamic?: boolean;                            // [Dynamic] Set to true on a dynamic rule
   apfCaptions?: boolean;                         // [Cue] Display an HTML version of the caption/subtitle text: Requires videoCueHideCues = true
   apfCaptionsSelector?: string;                  // [Cue] Selector for container that will hold the custom HTML captions
+  buildTarget?: string;                          // [All] Only allow rule to run on a specific buildTarget
   checkInterval?: number;                        // [Watcher] Set a custom watch interval (in ms, Default: 20)
   className?: string;                            // [Element] node.className.includes()
   containsSelector?: string;                     // [Element] node.querySelector() [Not commonly used]

--- a/src/script/lib/globals.d.ts
+++ b/src/script/lib/globals.d.ts
@@ -50,6 +50,10 @@ interface AudioRule {
   videoSelector?: string;                        // [Cue,Watcher] Selector for video, also used for volume muteMethod (Default: 'video')
 }
 
+interface AudioSites {
+  [site: string]: AudioRule[];
+}
+
 interface BackgroundData {
   disabledTab?: boolean;
 }

--- a/src/script/lib/helper.ts
+++ b/src/script/lib/helper.ts
@@ -4,6 +4,10 @@ export function booleanToNumber(value: boolean): number {
   return value ? Constants.TRUE : Constants.FALSE;
 }
 
+export function cloneWithJSON(object) {
+  return JSON.parse(JSON.stringify(object));
+}
+
 /* istanbul ignore next */
 export function dynamicList(list: string[], select: HTMLSelectElement, upperCaseFirstChar: boolean = false, title?: string) {
   removeChildren(select);

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -1723,7 +1723,7 @@ export default class OptionPage {
     const select = contentLeft.querySelector('#siteSelect') as HTMLSelectElement;
     removeChildren(select);
 
-    this.supportedAudioSites = WebAudio.supportedSites(WebConfig.BUILD.target);
+    this.supportedAudioSites = WebAudio.supportedSites();
     const sortedSites = Domain.sortedKeys(this.supportedAudioSites);
     sortedSites.forEach((site) => {
       const optionElement = document.createElement('option');

--- a/src/script/optionPage.ts
+++ b/src/script/optionPage.ts
@@ -5,7 +5,7 @@ import Domain from './domain';
 import OptionAuth from './optionAuth';
 import DataMigration from './dataMigration';
 import Bookmarklet from './bookmarklet';
-import WebAudioSites from './webAudioSites';
+import WebAudio from './webAudio';
 import Logger from './lib/logger';
 import {
   booleanToNumber,
@@ -26,6 +26,7 @@ export default class OptionPage {
   darkModeButton: Element;
   lightModeButton: Element;
   prefersDarkScheme: boolean;
+  supportedAudioSites: AudioSites;
   themeElements: Element[];
 
   static readonly activeClass = 'w3-flat-belize-hole';
@@ -1711,7 +1712,7 @@ export default class OptionPage {
     const select = document.querySelector('#supportedAudioSitesModal select#siteSelect') as HTMLSelectElement;
     const textArea = document.querySelector('#supportedAudioSitesModal div#modalContentRight textarea') as HTMLTextAreaElement;
     const config = {};
-    config[select.value] = WebAudioSites.sites[select.value];
+    config[select.value] = this.supportedAudioSites[select.value];
     textArea.textContent = JSON.stringify(config, null, 2);
   }
 
@@ -1722,7 +1723,8 @@ export default class OptionPage {
     const select = contentLeft.querySelector('#siteSelect') as HTMLSelectElement;
     removeChildren(select);
 
-    const sortedSites = Domain.sortedKeys(WebAudioSites.sites);
+    this.supportedAudioSites = WebAudio.supportedSites(WebConfig.BUILD.target);
+    const sortedSites = Domain.sortedKeys(this.supportedAudioSites);
     sortedSites.forEach((site) => {
       const optionElement = document.createElement('option');
       optionElement.value = site;

--- a/src/script/popup.ts
+++ b/src/script/popup.ts
@@ -137,7 +137,7 @@ class Popup {
       dynamicList(wordlists, wordlistSelect);
       wordlistSelect.selectedIndex = wordlistIndex;
       if (this.cfg.muteAudio) {
-        this.audioSiteKeys = Object.keys(WebAudio.supportedAndCustomSites(WebConfig.BUILD.target, this.cfg.customAudioSites));
+        this.audioSiteKeys = Object.keys(WebAudio.supportedAndCustomSites(this.cfg.customAudioSites));
         if (this.audioSiteKeys.includes(this.domain.cfgKey)) {
           audioPage = true;
           const audioWordlistIndex = this.domain.audioWordlistId >= 0 ? this.domain.audioWordlistId + 1 : 0;

--- a/src/script/popup.ts
+++ b/src/script/popup.ts
@@ -1,6 +1,6 @@
 import Constants from './lib/constants';
 import { dynamicList } from './lib/helper';
-import WebAudioSites from './webAudioSites';
+import WebAudio from './webAudio';
 import WebConfig from './webConfig';
 import Domain from './domain';
 import Page from './page';
@@ -137,7 +137,7 @@ class Popup {
       dynamicList(wordlists, wordlistSelect);
       wordlistSelect.selectedIndex = wordlistIndex;
       if (this.cfg.muteAudio) {
-        this.audioSiteKeys = Object.keys(WebAudioSites.combineSites(this.cfg.customAudioSites));
+        this.audioSiteKeys = Object.keys(WebAudio.supportedAndCustomSites(WebConfig.BUILD.target, this.cfg.customAudioSites));
         if (this.audioSiteKeys.includes(this.domain.cfgKey)) {
           audioPage = true;
           const audioWordlistIndex = this.domain.audioWordlistId >= 0 ? this.domain.audioWordlistId + 1 : 0;

--- a/src/script/webAudio.ts
+++ b/src/script/webAudio.ts
@@ -1,7 +1,7 @@
 import Constants from './lib/constants';
 import WebFilter from './webFilter';
 import BookmarkletFilter from './bookmarkletFilter';
-import { defaultTargetConfig, supportedSites } from './webAudioSites';
+import { defaultTargetConfig, safariTargetConfig, supportedSites } from './webAudioSites';
 import {
   getElement,
   getElements,
@@ -69,6 +69,8 @@ export default class WebAudio {
 
   static getBuildTargetConfig(buildTarget: string) {
     switch (buildTarget) {
+      case Constants.BUILD_TARGET_SAFARI:
+        return safariTargetConfig;
       default:
         return defaultTargetConfig;
     }

--- a/src/script/webAudio.ts
+++ b/src/script/webAudio.ts
@@ -1,7 +1,7 @@
 import Constants from './lib/constants';
 import WebFilter from './webFilter';
 import BookmarkletFilter from './bookmarkletFilter';
-import { defaultTargetConfig, safariTargetConfig, supportedSites } from './webAudioSites';
+import { defaultTargetConfig, iOSTargetConfig, safariTargetConfig, supportedSites } from './webAudioSites';
 import {
   getElement,
   getElements,
@@ -69,6 +69,8 @@ export default class WebAudio {
 
   static getBuildTargetConfig() {
     switch (WebConfig.BUILD.target) {
+      case Constants.BUILD_TARGET_IOS:
+        return iOSTargetConfig;
       case Constants.BUILD_TARGET_SAFARI:
         return safariTargetConfig;
       default:

--- a/src/script/webAudio.ts
+++ b/src/script/webAudio.ts
@@ -30,7 +30,7 @@ export default class WebAudio {
   lastProcessedText: string;
   muted: boolean;
   rules: AudioRule[];
-  sites: { [site: string]: AudioRule[] };
+  sites: AudioSites;
   siteKey: string;
   supportedPage: boolean;
   unmuteTimeout: number;

--- a/src/script/webAudio.ts
+++ b/src/script/webAudio.ts
@@ -1,7 +1,7 @@
 import Constants from './lib/constants';
 import WebFilter from './webFilter';
 import BookmarkletFilter from './bookmarkletFilter';
-import WebAudioSites from './webAudioSites';
+import { defaultTargetConfig, supportedSites } from './webAudioSites';
 import {
   getElement,
   getElements,
@@ -67,6 +67,24 @@ export default class WebAudio {
     videoCueLanguage: 'language',
   };
 
+  static getBuildTargetConfig(buildTarget: string) {
+    switch (buildTarget) {
+      default:
+        return defaultTargetConfig;
+    }
+  }
+
+  static supportedSites(buildTarget: string): AudioSites {
+    const buildTargetConfig = WebAudio.getBuildTargetConfig(buildTarget);
+    const siteConfig = Object.assign({}, supportedSites, buildTargetConfig.sites);
+    buildTargetConfig.disabledSites.forEach((disabledSite) => { delete siteConfig[disabledSite]; });
+    return siteConfig;
+  }
+
+  static supportedAndCustomSites(buildTarget: string, customConfig: AudioSites) {
+    return Object.assign({}, WebAudio.supportedSites(buildTarget), customConfig);
+  }
+
   constructor(filter: WebFilter | BookmarkletFilter) {
     this.filter = filter;
     logger.setLevel(this.filter.cfg.loggingLevel);
@@ -84,7 +102,7 @@ export default class WebAudio {
     ) {
       filter.cfg.customAudioSites = {};
     }
-    this.sites = WebAudioSites.combineSites(filter.cfg.customAudioSites);
+    this.sites = WebAudio.supportedAndCustomSites(WebConfig.BUILD.target, filter.cfg.customAudioSites);
     this.volume = 1;
     this.wordlistId = filter.audioWordlistId;
     this.youTubeAutoSubsMax = filter.cfg.youTubeAutoSubsMax * 1000;

--- a/src/script/webAudio.ts
+++ b/src/script/webAudio.ts
@@ -67,8 +67,8 @@ export default class WebAudio {
     videoCueLanguage: 'language',
   };
 
-  static getBuildTargetConfig(buildTarget: string) {
-    switch (buildTarget) {
+  static getBuildTargetConfig() {
+    switch (WebConfig.BUILD.target) {
       case Constants.BUILD_TARGET_SAFARI:
         return safariTargetConfig;
       default:
@@ -98,16 +98,16 @@ export default class WebAudio {
     });
   }
 
-  static supportedSites(buildTarget: string, removeUnsupported: boolean = true): AudioSites {
-    const buildTargetConfig = WebAudio.getBuildTargetConfig(buildTarget);
+  static supportedSites(removeUnsupported: boolean = true): AudioSites {
+    const buildTargetConfig = WebAudio.getBuildTargetConfig();
     const siteConfig = Object.assign({}, supportedSites, buildTargetConfig.sites);
     buildTargetConfig.disabledSites.forEach((disabledSite) => { delete siteConfig[disabledSite]; });
     if (removeUnsupported) { WebAudio.removeUnsupportedSites(siteConfig); }
     return siteConfig;
   }
 
-  static supportedAndCustomSites(buildTarget: string, customConfig: AudioSites) {
-    const combinedSites = Object.assign({}, WebAudio.supportedSites(buildTarget, false), customConfig);
+  static supportedAndCustomSites(customConfig: AudioSites) {
+    const combinedSites = Object.assign({}, WebAudio.supportedSites(false), customConfig);
     WebAudio.removeUnsupportedSites(combinedSites);
     return combinedSites;
   }
@@ -129,7 +129,7 @@ export default class WebAudio {
     ) {
       filter.cfg.customAudioSites = {};
     }
-    this.sites = WebAudio.supportedAndCustomSites(WebConfig.BUILD.target, filter.cfg.customAudioSites);
+    this.sites = WebAudio.supportedAndCustomSites(filter.cfg.customAudioSites);
     this.volume = 1;
     this.wordlistId = filter.audioWordlistId;
     this.youTubeAutoSubsMax = filter.cfg.youTubeAutoSubsMax * 1000;

--- a/src/script/webAudio.ts
+++ b/src/script/webAudio.ts
@@ -494,6 +494,10 @@ export default class WebAudio {
           this.initWatcherRule(rule);
           if (!rule.disabled) { this.watcherRuleIds.push(ruleId); }
           break;
+        case 'ytauto':
+          // This rule doesn't run like other rules, and is marked as disabled
+          rule.disabled = true;
+          break;
       }
       if (!rule.disabled) {
         this.enabledRuleIds.push(ruleId);
@@ -534,7 +538,8 @@ export default class WebAudio {
       this.filter.cfg.addWord(youTubeAutoCensor, youTubeAutoCensorOptions);
 
       // Setup rule for YouTube Auto Subs
-      this.youTubeAutoSubsRule = { filterSubtitles: true, mode: 'ytauto', muteMethod: this.filter.cfg.muteMethod } as AudioRule;
+      this.youTubeAutoSubsRule = { mode: 'ytauto' } as AudioRule;
+      this.initRule(this.youTubeAutoSubsRule);
     }
   }
 

--- a/src/script/webAudioSites.ts
+++ b/src/script/webAudioSites.ts
@@ -8,12 +8,16 @@ export const defaultTargetConfig: BuildTargetSites = {
 
 export const iOSTargetConfig: BuildTargetSites = {
   disabledSites: [],
-  sites: {},
+  sites: {
+    'play.stan.com.au': [{ mode: 'cue', videoCueLanguage: 'en' }],
+  },
 };
 
 export const safariTargetConfig: BuildTargetSites = {
   disabledSites: [],
-  sites: {},
+  sites: {
+    'play.stan.com.au': [{ mode: 'cue', videoCueLanguage: 'en' }],
+  },
 };
 
 export const supportedSites: AudioSites = {
@@ -226,7 +230,7 @@ export const supportedSites: AudioSites = {
   'www.showmax.com': [{ ignoreMutations: true, mode: 'elementChild', parentSelector: 'div.contentWrapper > div.subtitles--3EXhT', simpleUnmute: true, tagName: '#text' }],
   'www.showtime.com': [{ mode: 'cue', videoCueHideCues: true, videoCueLanguage: 'en', videoCueRequireShowing: false }],
   'watch.sling.com': [{ className: 'bmpui-subtitle-region-container', mode: 'element', subtitleSelector: 'DIV.bmpui-container-wrapper > SPAN.bmpui-ui-subtitle-label', tagName: 'DIV' }],
-  'play.stan.com.au': [{ ignoreMutations: true, mode: 'elementChild', parentSelector: 'div.clpp-subtitles-container', simpleUnmute: true, tagName: '#text' }],
+  'play.stan.com.au': [{ ignoreMutations: true, mode: 'elementChild', parentSelector: 'div.clpp-text-container', simpleUnmute: true, tagName: 'DIV' }],
   'www.starz.com': [{ mode: 'elementChild', parentSelector: 'starz-captions > div.cue-list', tagName: 'SPAN' }],
   'www.syfy.com': [{ className: 'ttr-line', mode: 'element', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' }],
   'www.tntdrama.com': [{ mode: 'cue', videoCueLanguage: 'en', videoSelector: 'video.top-media-element' }],

--- a/src/script/webAudioSites.ts
+++ b/src/script/webAudioSites.ts
@@ -1,237 +1,236 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import Constants from './lib/constants';
 
-export default class WebAudioSites {
-  static combineSites(sites: AudioSites = {}): AudioSites {
-    return Object.assign({}, WebAudioSites.sites, sites);
-  }
+export const defaultTargetConfig: BuildTargetSites = {
+  sites: {},
+  disabledSites: [],
+};
 
-  static sites: AudioSites = {
-    'abc.com': [
-      { className: 'akamai-caption-text', mode: 'element', tagName: 'DIV' },
-      { className: 'amp-caption-area', displaySelector: 'div.amp-caption-area', mode: 'element', muteMethod: Constants.MUTE_METHODS.VIDEO_VOLUME, subtitleSelector: 'div.amp-caption > p', tagName: 'DIV' },
-    ],
-    'iview.abc.net.au': [{ mode: 'element', subtitleSelector: 'div.jw-text-track-cue', tagName: 'div' }],
-    'acorn.tv': [
-      {
-        iframe: true,
-        mode: 'elementChild',
-        parentSelector: 'div.vjs-text-track-display',
-        simpleUnmute: true,
-        subtitleSelector: ':scope div > div',
-        tagName: 'DIV',
-      }
-    ],
-    'smile.amazon.com': [
-      {
-        displayHide: 'none',
-        displaySelector: 'div.webPlayerContainer div.f35bt6a',
-        displayShow: '',
-        iframe: false,
-        mode: 'watcher',
-        parentSelector: 'div.webPlayerContainer div span > span',
-        videoSelector: 'div.webPlayerElement video[src]',
-      }
-    ],
-    'www.amazon.co.uk': [
-      {
-        displayHide: 'none',
-        displaySelector: 'div.webPlayerContainer div.f35bt6a',
-        displayShow: '',
-        iframe: false,
-        mode: 'watcher',
-        parentSelector: 'div.webPlayerContainer div span > span',
-        videoSelector: 'div.webPlayerElement video[src]',
-      }
-    ],
-    'www.amazon.com': [
-      {
-        displayHide: 'none',
-        displaySelector: 'div.webPlayerContainer div.f35bt6a',
-        displayShow: '',
-        iframe: false,
-        mode: 'watcher',
-        parentSelector: 'div.webPlayerContainer div span > span',
-        videoSelector: 'div.webPlayerElement video[src]',
-      }
-    ],
-    'www.amc.com': [
-      { className: 'ttr-container', mode: 'element', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' },
-      { mode: 'cue', videoCueLanguage: 'en', videoSelector: 'video' },
-    ],
-    'tv.apple.com': [
-      {
-        displaySelector: 'div.video-container > div > div > div',
-        mode: 'elementChild',
-        muteMethod: Constants.MUTE_METHODS.TAB,
-        parentSelector: 'div.video-container',
-        preserveWhiteSpace: true,
-        rootNode: true,
-        subtitleSelector: 'div > div > div > div > div',
-        tagName: 'DIV',
-      },
-      {
-        displaySelector: 'div.video-container > div > div > div',
-        mode: 'elementChild',
-        muteMethod: Constants.MUTE_METHODS.TAB,
-        parentSelector: 'div.video-container',
-        preserveWhiteSpace: true,
-        rootNode: true,
-        subtitleSelector: 'div > div > div > div > span',
-        tagName: 'DIV',
-      },
-    ],
-    'www.att.tv': [{ mode: 'cue', videoSelector: 'video#quickplayPlayer' }],
-    'www.attwatchtv.com': [{ mode: 'cue', videoSelector: 'video#quickplayPlayer' }],
-    'www.bbc.co.uk': [
-      {
-        displaySelector: 'smp-toucan-player >>> smp-video-layout >>> smp-subtitles >>> div',
-        iframe: false,
-        mode: 'watcher',
-        subtitleSelector: 'smp-toucan-player >>> smp-video-layout >>> smp-subtitles >>> div[lang] p span span',
-        videoSelector: 'smp-toucan-player >>> smp-playback >>> video'
-      },
-    ],
-    'www.britbox.com': [
-      { className: 'bmpui-ui-subtitle-label', mode: 'element', tagName: 'SPAN' },
-      { className: 'bmpui-subtitle-region-container', mode: 'element', subtitleSelector: 'div.bmpui-container-wrapper > span.bmpui-ui-subtitle-label', tagName: 'div' },
-    ],
-    'gem.cbc.ca': [{ className: 'jw-text-track-container', mode: 'element', subtitleSelector: 'div.jw-text-track-cue', tagName: 'DIV' }],
-    'www.cbs.com': [{ mode: 'cue', videoCueLanguage: 'en', videoCueRequireShowing: false }],
-    'www.channel4.com': [{ displaySelector: 'div.subtitles-container', mode: 'elementChild', parentSelector: 'div.subtitles-container', tagName: 'SPAN' }],
-    'www.crackle.com': [{ ignoreMutations: true, mode: 'elementChild', parentSelector: 'div.clpp-subtitles-container', simpleUnmute: true, tagName: '#text' }],
-    'www.criterionchannel.com': [{ iframe: true, mode: 'cue', videoCueHideCues: true, videoCueRequireShowing: false }],
-    'beta.crunchyroll.com': [
-      {
-        apfCaptions: true,
-        apfCaptionsSelector: 'vilosVttJs',
-        displaySelector: 'canvas#velocity-canvas',
-        externalSub: true,
-        externalSubTrackMode: 'hidden',
-        externalSubVar: 'window.v1config.media.subtitles',
-        iframe: true,
-        mode: 'cue',
-        videoCueLanguage: 'en-US',
-        videoCueRequireShowing: false
-      },
-    ],
-    'www.crunchyroll.com': [
-      {
-        apfCaptions: true,
-        apfCaptionsSelector: 'vilosVttJs',
-        displaySelector: 'canvas#velocity-canvas',
-        externalSub: true,
-        externalSubTrackMode: 'hidden',
-        externalSubVar: 'window.v1config.media.subtitles',
-        iframe: true,
-        mode: 'cue',
-        videoCueLanguage: 'enUS',
-        videoCueRequireShowing: false,
-        videoSelector: 'video#player0',
-      },
-    ],
-    'www.cwtv.com': [
-      { className: 'ttr-container', convertBreaks: true, mode: 'element', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' },
-      { className: 'ttr-line', convertBreaks: true, mode: 'element', note: '[CC]', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' },
-    ],
-    'www.discoveryplus.com': [{ displaySelector: 'div.cjRVXG', mode: 'cue', videoCueKind: 'captions', videoCueLanguage: 'en' }],
-    'www.dishanywhere.com': [
-      { className: 'bmpui-ui-subtitle-label', mode: 'element', tagName: 'SPAN' },
-      { className: 'bmpui-subtitle-region-container', mode: 'element', subtitleSelector: 'div.bmpui-container-wrapper > span.bmpui-ui-subtitle-label', tagName: 'div' },
-    ],
-    'www.disneyplus.com': [{ className: 'dss-subtitle-renderer-wrapper', mode: 'element', subtitleSelector: 'div.dss-subtitle-renderer-cue-window span.dss-subtitle-renderer-line', tagName: 'DIV' }],
-    'www.fox.com': [{ className: 'jw-text-track-container', mode: 'element', subtitleSelector: 'div.jw-text-track-cue', tagName: 'DIV' }],
-    'www.fubo.tv': [
-      {
-        displayHide: 'none',
-        displaySelector: 'div.bmpui-ui-subtitle-overlay',
-        iframe: false,
-        mode: 'watcher',
-        parentSelector: 'div.bmpui-ui-subtitle-overlay',
-        subtitleSelector: 'div.bmpui-ui-subtitle-overlay span',
-      },
-    ],
-    'www.funimation.com': [
-      {
-        displaySelector: 'div > div.vjs-text-track-cue',
-        mode: 'element',
-        subtitleSelector: 'div.vjs-text-track-cue > div',
-        tagName: 'DIV'
-      },
-      {
-        iframe: true,
-        mode: 'elementChild',
-        note: 'Embedded videos',
-        parentSelector: 'div.vjs-text-track-display',
-        simpleUnmute: true,
-        subtitleSelector: ':scope div > div',
-        tagName: 'DIV',
-      },
-    ],
-    'fxnow.fxnetworks.com': [{ iframe: true, mode: 'cue', videoSelector: 'video' }],
-    'play.google.com': [{ className: 'lava-timed-text-window', mode: 'element', subtitleSelector: 'span.lava-timed-text-caption', tagName: 'DIV' }],
-    'play.hbomax.com': [{ displayElementLevels: 5, displayVisibility: true, mode: 'watcher', showSubtitles: Constants.SHOW_SUBTITLES.ALL, subtitleSelector: "span[style^='font-family: font']" }],
-    'www.hidive.com': [{ className: 'rmp-cc-container', mode: 'element', subtitleSelector: 'div.rmp-cc-cue > span', tagName: 'DIV' }],
-    'www.hulu.com': [
-      { className: 'caption-text-box', displaySelector: 'div.caption-text-box', mode: 'element', subtitleSelector: 'p', tagName: 'DIV' },
-      { displaySelector: 'div.CaptionBox', mode: 'elementChild', parentSelector: 'div.CaptionBox', tagName: 'P' }
-    ],
-    'www.itv.com': [{ mode: 'cue', videoCueLanguage: 'en' }],
-    'www.nbc.com': [
-      { className: 'ttr-line', mode: 'element', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' },
-      { mode: 'cue', videoCueLanguage: 'en' },
-    ],
-    'www.netflix.com': [
-      { className: 'player-timedtext-text-container', mode: 'element', note: 'Fallback compatibility', subtitleSelector: 'span > span', tagName: 'DIV' },
-      { className: 'player-timedtext-text-container', mode: 'element', subtitleSelector: 'span', tagName: 'DIV' },
-    ],
-    'www.paramountplus.com': [{ mode: 'cue', videoCueHideCues: true, videoCueLanguage: 'en', videoCueRequireShowing: false }],
-    'www.pbs.org': [{ iframe: true, mode: 'element', subtitleSelector: 'div.vjs-text-track-cue > div', tagName: 'DIV' }],
-    'www.peacocktv.com': [
-      { displaySelector: 'div.video-player__subtitles', mode: 'elementChild', parentSelector: 'div.video-player__subtitles > div', simpleUnmute: true, tagName: '#text' },
-      { displaySelector: 'div.video-player__subtitles', mode: 'elementChild', parentSelector: 'div.video-player__subtitles > div', subtitleSelector: 'SPAN > SPAN', tagName: 'DIV' },
-      { displaySelector: 'div.video-player__subtitles', mode: 'elementChild', parentSelector: 'div.video-player__subtitles > div', tagName: 'SPAN' },
-    ],
-    'www.philo.com': [{ mode: 'cue' }],
-    'app.plex.tv': [
-      { dataPropPresent: 'dialogueId', mode: 'element', subtitleSelector: 'span > span', tagName: 'DIV' },
-      { containsSelector: 'div[data-dialogue-id]', mode: 'element', subtitleSelector: 'span > span', tagName: 'DIV' },
-    ],
-    'pluto.tv': [{ mode: 'cue', videoCueHideCues: true, videoCueRequireShowing: false }],
-    'www.primevideo.com': [
-      {
-        displayHide: 'none',
-        displaySelector: 'div.webPlayerContainer div.f35bt6a',
-        displayShow: '',
-        iframe: false,
-        mode: 'watcher',
-        parentSelector: 'div.webPlayerContainer div span > span',
-        videoSelector: 'div.webPlayerElement video[src]',
-      }
-    ],
-    'www.redbox.com': [{ mode: 'elementChild', parentSelector: 'div.rb-text-container', subtitleSelector: 'SPAN > SPAN', tagName: 'DIV' }],
-    'watch.redeemtv.com': [{ convertBreaks: true, displaySelector: 'div.vp-captions', mode: 'elementChild', parentSelector: 'div.vp-captions', tagName: 'SPAN' }],
-    'therokuchannel.roku.com': [{ mode: 'element', subtitleSelector: 'div.vjs-text-track-cue > div', tagName: 'DIV' }],
-    'www.sbs.com.au': [{ className: 'bmpui-subtitle-region-container', mode: 'element', subtitleSelector: 'DIV.bmpui-container-wrapper > SPAN.bmpui-ui-subtitle-label > SPAN', tagName: 'DIV' }],
-    'www.showmax.com': [{ ignoreMutations: true, mode: 'elementChild', parentSelector: 'div.contentWrapper > div.subtitles--3EXhT', simpleUnmute: true, tagName: '#text' }],
-    'www.showtime.com': [{ mode: 'cue', videoCueHideCues: true, videoCueLanguage: 'en', videoCueRequireShowing: false }],
-    'watch.sling.com': [{ className: 'bmpui-subtitle-region-container', mode: 'element', subtitleSelector: 'DIV.bmpui-container-wrapper > SPAN.bmpui-ui-subtitle-label', tagName: 'DIV' }],
-    'play.stan.com.au': [{ ignoreMutations: true, mode: 'elementChild', parentSelector: 'div.clpp-subtitles-container', simpleUnmute: true, tagName: '#text' }],
-    'www.starz.com': [{ mode: 'elementChild', parentSelector: 'starz-captions > div.cue-list', tagName: 'SPAN' }],
-    'www.syfy.com': [{ className: 'ttr-line', mode: 'element', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' }],
-    'www.tntdrama.com': [{ mode: 'cue', videoCueLanguage: 'en', videoSelector: 'video.top-media-element' }],
-    'tubitv.com': [{ mode: 'elementChild', parentSelector: 'div#captionsComponent', tagName: 'SPAN' }],
-    'www.universalkids.com': [{ mode: 'element', subtitleSelector: 'div.gwt-HTML', tagName: 'DIV' }],
-    'www.usanetwork.com': [{ className: 'ttr-line', mode: 'element', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' }],
-    'vimeo.com': [{ mode: 'element', tagName: 'SPAN', note: 'Only tested with single-line captions', className: 'vp-captions-line', displaySelector: 'div.vp-captions > span.vp-captions-window' }],
-    'player.vimeo.com': [{ mode: 'element', tagName: 'SPAN', note: 'For embedded videos', className: 'vp-captions-line', displaySelector: 'div.vp-captions > span.vp-captions-window' }],
-    'www.vudu.com': [{ mode: 'element', subtitleSelector: 'span.subtitles', tagName: 'DIV' }],
-    'vrv.co': [
-      { displaySelector: 'div.libassjs-canvas-parent', externalSub: true, externalSubVar: 'window.vilos.content.captions', iframe: true, mode: 'cue', videoCueLanguage: 'en-US', videoCueRequireShowing: false },
-      { displaySelector: 'div.libassjs-canvas-parent', externalSub: true, externalSubVar: 'window.vilos.content.subtitles', iframe: true, mode: 'cue', videoCueLanguage: 'en-US', videoCueRequireShowing: false },
-    ],
-    'm.youtube.com': [{ className: 'caption-window', mode: 'element', subtitleSelector: 'span.ytp-caption-segment', tagName: 'DIV' }],
-    'tv.youtube.com': [{ className: 'caption-window', mode: 'element', subtitleSelector: 'span.ytp-caption-segment', tagName: 'DIV' }],
-    'www.youtube.com': [{ className: 'caption-window', mode: 'element', subtitleSelector: 'span.ytp-caption-segment', tagName: 'DIV' }],
-  };
-}
+export const supportedSites: AudioSites = {
+  'abc.com': [
+    { className: 'akamai-caption-text', mode: 'element', tagName: 'DIV' },
+    { className: 'amp-caption-area', displaySelector: 'div.amp-caption-area', mode: 'element', muteMethod: Constants.MUTE_METHODS.VIDEO_VOLUME, subtitleSelector: 'div.amp-caption > p', tagName: 'DIV' },
+  ],
+  'iview.abc.net.au': [{ mode: 'element', subtitleSelector: 'div.jw-text-track-cue', tagName: 'div' }],
+  'acorn.tv': [
+    {
+      iframe: true,
+      mode: 'elementChild',
+      parentSelector: 'div.vjs-text-track-display',
+      simpleUnmute: true,
+      subtitleSelector: ':scope div > div',
+      tagName: 'DIV',
+    }
+  ],
+  'smile.amazon.com': [
+    {
+      displayHide: 'none',
+      displaySelector: 'div.webPlayerContainer div.f35bt6a',
+      displayShow: '',
+      iframe: false,
+      mode: 'watcher',
+      parentSelector: 'div.webPlayerContainer div span > span',
+      videoSelector: 'div.webPlayerElement video[src]',
+    }
+  ],
+  'www.amazon.co.uk': [
+    {
+      displayHide: 'none',
+      displaySelector: 'div.webPlayerContainer div.f35bt6a',
+      displayShow: '',
+      iframe: false,
+      mode: 'watcher',
+      parentSelector: 'div.webPlayerContainer div span > span',
+      videoSelector: 'div.webPlayerElement video[src]',
+    }
+  ],
+  'www.amazon.com': [
+    {
+      displayHide: 'none',
+      displaySelector: 'div.webPlayerContainer div.f35bt6a',
+      displayShow: '',
+      iframe: false,
+      mode: 'watcher',
+      parentSelector: 'div.webPlayerContainer div span > span',
+      videoSelector: 'div.webPlayerElement video[src]',
+    }
+  ],
+  'www.amc.com': [
+    { className: 'ttr-container', mode: 'element', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' },
+    { mode: 'cue', videoCueLanguage: 'en', videoSelector: 'video' },
+  ],
+  'tv.apple.com': [
+    {
+      displaySelector: 'div.video-container > div > div > div',
+      mode: 'elementChild',
+      muteMethod: Constants.MUTE_METHODS.TAB,
+      parentSelector: 'div.video-container',
+      preserveWhiteSpace: true,
+      rootNode: true,
+      subtitleSelector: 'div > div > div > div > div',
+      tagName: 'DIV',
+    },
+    {
+      displaySelector: 'div.video-container > div > div > div',
+      mode: 'elementChild',
+      muteMethod: Constants.MUTE_METHODS.TAB,
+      parentSelector: 'div.video-container',
+      preserveWhiteSpace: true,
+      rootNode: true,
+      subtitleSelector: 'div > div > div > div > span',
+      tagName: 'DIV',
+    },
+  ],
+  'www.att.tv': [{ mode: 'cue', videoSelector: 'video#quickplayPlayer' }],
+  'www.attwatchtv.com': [{ mode: 'cue', videoSelector: 'video#quickplayPlayer' }],
+  'www.bbc.co.uk': [
+    {
+      displaySelector: 'smp-toucan-player >>> smp-video-layout >>> smp-subtitles >>> div',
+      iframe: false,
+      mode: 'watcher',
+      subtitleSelector: 'smp-toucan-player >>> smp-video-layout >>> smp-subtitles >>> div[lang] p span span',
+      videoSelector: 'smp-toucan-player >>> smp-playback >>> video'
+    },
+  ],
+  'www.britbox.com': [
+    { className: 'bmpui-ui-subtitle-label', mode: 'element', tagName: 'SPAN' },
+    { className: 'bmpui-subtitle-region-container', mode: 'element', subtitleSelector: 'div.bmpui-container-wrapper > span.bmpui-ui-subtitle-label', tagName: 'div' },
+  ],
+  'gem.cbc.ca': [{ className: 'jw-text-track-container', mode: 'element', subtitleSelector: 'div.jw-text-track-cue', tagName: 'DIV' }],
+  'www.cbs.com': [{ mode: 'cue', videoCueLanguage: 'en', videoCueRequireShowing: false }],
+  'www.channel4.com': [{ displaySelector: 'div.subtitles-container', mode: 'elementChild', parentSelector: 'div.subtitles-container', tagName: 'SPAN' }],
+  'www.crackle.com': [{ ignoreMutations: true, mode: 'elementChild', parentSelector: 'div.clpp-subtitles-container', simpleUnmute: true, tagName: '#text' }],
+  'www.criterionchannel.com': [{ iframe: true, mode: 'cue', videoCueHideCues: true, videoCueRequireShowing: false }],
+  'beta.crunchyroll.com': [
+    {
+      apfCaptions: true,
+      apfCaptionsSelector: 'vilosVttJs',
+      displaySelector: 'canvas#velocity-canvas',
+      externalSub: true,
+      externalSubTrackMode: 'hidden',
+      externalSubVar: 'window.v1config.media.subtitles',
+      iframe: true,
+      mode: 'cue',
+      videoCueLanguage: 'en-US',
+      videoCueRequireShowing: false
+    },
+  ],
+  'www.crunchyroll.com': [
+    {
+      apfCaptions: true,
+      apfCaptionsSelector: 'vilosVttJs',
+      displaySelector: 'canvas#velocity-canvas',
+      externalSub: true,
+      externalSubTrackMode: 'hidden',
+      externalSubVar: 'window.v1config.media.subtitles',
+      iframe: true,
+      mode: 'cue',
+      videoCueLanguage: 'enUS',
+      videoCueRequireShowing: false,
+      videoSelector: 'video#player0',
+    },
+  ],
+  'www.cwtv.com': [
+    { className: 'ttr-container', convertBreaks: true, mode: 'element', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' },
+    { className: 'ttr-line', convertBreaks: true, mode: 'element', note: '[CC]', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' },
+  ],
+  'www.discoveryplus.com': [{ displaySelector: 'div.cjRVXG', mode: 'cue', videoCueKind: 'captions', videoCueLanguage: 'en' }],
+  'www.dishanywhere.com': [
+    { className: 'bmpui-ui-subtitle-label', mode: 'element', tagName: 'SPAN' },
+    { className: 'bmpui-subtitle-region-container', mode: 'element', subtitleSelector: 'div.bmpui-container-wrapper > span.bmpui-ui-subtitle-label', tagName: 'div' },
+  ],
+  'www.disneyplus.com': [{ className: 'dss-subtitle-renderer-wrapper', mode: 'element', subtitleSelector: 'div.dss-subtitle-renderer-cue-window span.dss-subtitle-renderer-line', tagName: 'DIV' }],
+  'www.fox.com': [{ className: 'jw-text-track-container', mode: 'element', subtitleSelector: 'div.jw-text-track-cue', tagName: 'DIV' }],
+  'www.fubo.tv': [
+    {
+      displayHide: 'none',
+      displaySelector: 'div.bmpui-ui-subtitle-overlay',
+      iframe: false,
+      mode: 'watcher',
+      parentSelector: 'div.bmpui-ui-subtitle-overlay',
+      subtitleSelector: 'div.bmpui-ui-subtitle-overlay span',
+    },
+  ],
+  'www.funimation.com': [
+    {
+      displaySelector: 'div > div.vjs-text-track-cue',
+      mode: 'element',
+      subtitleSelector: 'div.vjs-text-track-cue > div',
+      tagName: 'DIV'
+    },
+    {
+      iframe: true,
+      mode: 'elementChild',
+      note: 'Embedded videos',
+      parentSelector: 'div.vjs-text-track-display',
+      simpleUnmute: true,
+      subtitleSelector: ':scope div > div',
+      tagName: 'DIV',
+    },
+  ],
+  'fxnow.fxnetworks.com': [{ iframe: true, mode: 'cue', videoSelector: 'video' }],
+  'play.google.com': [{ className: 'lava-timed-text-window', mode: 'element', subtitleSelector: 'span.lava-timed-text-caption', tagName: 'DIV' }],
+  'play.hbomax.com': [{ displayElementLevels: 5, displayVisibility: true, mode: 'watcher', showSubtitles: Constants.SHOW_SUBTITLES.ALL, subtitleSelector: "span[style^='font-family: font']" }],
+  'www.hidive.com': [{ className: 'rmp-cc-container', mode: 'element', subtitleSelector: 'div.rmp-cc-cue > span', tagName: 'DIV' }],
+  'www.hulu.com': [
+    { className: 'caption-text-box', displaySelector: 'div.caption-text-box', mode: 'element', subtitleSelector: 'p', tagName: 'DIV' },
+    { displaySelector: 'div.CaptionBox', mode: 'elementChild', parentSelector: 'div.CaptionBox', tagName: 'P' }
+  ],
+  'www.itv.com': [{ mode: 'cue', videoCueLanguage: 'en' }],
+  'www.nbc.com': [
+    { className: 'ttr-line', mode: 'element', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' },
+    { mode: 'cue', videoCueLanguage: 'en' },
+  ],
+  'www.netflix.com': [
+    { className: 'player-timedtext-text-container', mode: 'element', note: 'Fallback compatibility', subtitleSelector: 'span > span', tagName: 'DIV' },
+    { className: 'player-timedtext-text-container', mode: 'element', subtitleSelector: 'span', tagName: 'DIV' },
+  ],
+  'www.paramountplus.com': [{ mode: 'cue', videoCueHideCues: true, videoCueLanguage: 'en', videoCueRequireShowing: false }],
+  'www.pbs.org': [{ iframe: true, mode: 'element', subtitleSelector: 'div.vjs-text-track-cue > div', tagName: 'DIV' }],
+  'www.peacocktv.com': [
+    { displaySelector: 'div.video-player__subtitles', mode: 'elementChild', parentSelector: 'div.video-player__subtitles > div', simpleUnmute: true, tagName: '#text' },
+    { displaySelector: 'div.video-player__subtitles', mode: 'elementChild', parentSelector: 'div.video-player__subtitles > div', subtitleSelector: 'SPAN > SPAN', tagName: 'DIV' },
+    { displaySelector: 'div.video-player__subtitles', mode: 'elementChild', parentSelector: 'div.video-player__subtitles > div', tagName: 'SPAN' },
+  ],
+  'www.philo.com': [{ mode: 'cue' }],
+  'app.plex.tv': [
+    { dataPropPresent: 'dialogueId', mode: 'element', subtitleSelector: 'span > span', tagName: 'DIV' },
+    { containsSelector: 'div[data-dialogue-id]', mode: 'element', subtitleSelector: 'span > span', tagName: 'DIV' },
+  ],
+  'pluto.tv': [{ mode: 'cue', videoCueHideCues: true, videoCueRequireShowing: false }],
+  'www.primevideo.com': [
+    {
+      displayHide: 'none',
+      displaySelector: 'div.webPlayerContainer div.f35bt6a',
+      displayShow: '',
+      iframe: false,
+      mode: 'watcher',
+      parentSelector: 'div.webPlayerContainer div span > span',
+      videoSelector: 'div.webPlayerElement video[src]',
+    }
+  ],
+  'www.redbox.com': [{ mode: 'elementChild', parentSelector: 'div.rb-text-container', subtitleSelector: 'SPAN > SPAN', tagName: 'DIV' }],
+  'watch.redeemtv.com': [{ convertBreaks: true, displaySelector: 'div.vp-captions', mode: 'elementChild', parentSelector: 'div.vp-captions', tagName: 'SPAN' }],
+  'therokuchannel.roku.com': [{ mode: 'element', subtitleSelector: 'div.vjs-text-track-cue > div', tagName: 'DIV' }],
+  'www.sbs.com.au': [{ className: 'bmpui-subtitle-region-container', mode: 'element', subtitleSelector: 'DIV.bmpui-container-wrapper > SPAN.bmpui-ui-subtitle-label > SPAN', tagName: 'DIV' }],
+  'www.showmax.com': [{ ignoreMutations: true, mode: 'elementChild', parentSelector: 'div.contentWrapper > div.subtitles--3EXhT', simpleUnmute: true, tagName: '#text' }],
+  'www.showtime.com': [{ mode: 'cue', videoCueHideCues: true, videoCueLanguage: 'en', videoCueRequireShowing: false }],
+  'watch.sling.com': [{ className: 'bmpui-subtitle-region-container', mode: 'element', subtitleSelector: 'DIV.bmpui-container-wrapper > SPAN.bmpui-ui-subtitle-label', tagName: 'DIV' }],
+  'play.stan.com.au': [{ ignoreMutations: true, mode: 'elementChild', parentSelector: 'div.clpp-subtitles-container', simpleUnmute: true, tagName: '#text' }],
+  'www.starz.com': [{ mode: 'elementChild', parentSelector: 'starz-captions > div.cue-list', tagName: 'SPAN' }],
+  'www.syfy.com': [{ className: 'ttr-line', mode: 'element', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' }],
+  'www.tntdrama.com': [{ mode: 'cue', videoCueLanguage: 'en', videoSelector: 'video.top-media-element' }],
+  'tubitv.com': [{ mode: 'elementChild', parentSelector: 'div#captionsComponent', tagName: 'SPAN' }],
+  'www.universalkids.com': [{ mode: 'element', subtitleSelector: 'div.gwt-HTML', tagName: 'DIV' }],
+  'www.usanetwork.com': [{ className: 'ttr-line', mode: 'element', subtitleSelector: 'span.ttr-cue', tagName: 'DIV' }],
+  'vimeo.com': [{ mode: 'element', tagName: 'SPAN', note: 'Only tested with single-line captions', className: 'vp-captions-line', displaySelector: 'div.vp-captions > span.vp-captions-window' }],
+  'player.vimeo.com': [{ mode: 'element', tagName: 'SPAN', note: 'For embedded videos', className: 'vp-captions-line', displaySelector: 'div.vp-captions > span.vp-captions-window' }],
+  'www.vudu.com': [{ mode: 'element', subtitleSelector: 'span.subtitles', tagName: 'DIV' }],
+  'vrv.co': [
+    { displaySelector: 'div.libassjs-canvas-parent', externalSub: true, externalSubVar: 'window.vilos.content.captions', iframe: true, mode: 'cue', videoCueLanguage: 'en-US', videoCueRequireShowing: false },
+    { displaySelector: 'div.libassjs-canvas-parent', externalSub: true, externalSubVar: 'window.vilos.content.subtitles', iframe: true, mode: 'cue', videoCueLanguage: 'en-US', videoCueRequireShowing: false },
+  ],
+  'm.youtube.com': [{ className: 'caption-window', mode: 'element', subtitleSelector: 'span.ytp-caption-segment', tagName: 'DIV' }],
+  'tv.youtube.com': [{ className: 'caption-window', mode: 'element', subtitleSelector: 'span.ytp-caption-segment', tagName: 'DIV' }],
+  'www.youtube.com': [{ className: 'caption-window', mode: 'element', subtitleSelector: 'span.ytp-caption-segment', tagName: 'DIV' }],
+};

--- a/src/script/webAudioSites.ts
+++ b/src/script/webAudioSites.ts
@@ -6,6 +6,11 @@ export const defaultTargetConfig: BuildTargetSites = {
   disabledSites: [],
 };
 
+export const iOSTargetConfig: BuildTargetSites = {
+  sites: {},
+  disabledSites: [],
+};
+
 export const safariTargetConfig: BuildTargetSites = {
   sites: {},
   disabledSites: [],

--- a/src/script/webAudioSites.ts
+++ b/src/script/webAudioSites.ts
@@ -2,11 +2,11 @@
 import Constants from './lib/constants';
 
 export default class WebAudioSites {
-  static combineSites(sites: { [site: string]: AudioRule[] } = {}): { [site: string]: AudioRule[] } {
+  static combineSites(sites: AudioSites = {}): AudioSites {
     return Object.assign({}, WebAudioSites.sites, sites);
   }
 
-  static sites: { [site: string]: AudioRule[] } = {
+  static sites: AudioSites = {
     'abc.com': [
       { className: 'akamai-caption-text', mode: 'element', tagName: 'DIV' },
       { className: 'amp-caption-area', displaySelector: 'div.amp-caption-area', mode: 'element', muteMethod: Constants.MUTE_METHODS.VIDEO_VOLUME, subtitleSelector: 'div.amp-caption > p', tagName: 'DIV' },

--- a/src/script/webAudioSites.ts
+++ b/src/script/webAudioSites.ts
@@ -2,18 +2,18 @@
 import Constants from './lib/constants';
 
 export const defaultTargetConfig: BuildTargetSites = {
-  sites: {},
   disabledSites: [],
+  sites: {},
 };
 
 export const iOSTargetConfig: BuildTargetSites = {
-  sites: {},
   disabledSites: [],
+  sites: {},
 };
 
 export const safariTargetConfig: BuildTargetSites = {
-  sites: {},
   disabledSites: [],
+  sites: {},
 };
 
 export const supportedSites: AudioSites = {

--- a/src/script/webAudioSites.ts
+++ b/src/script/webAudioSites.ts
@@ -7,7 +7,10 @@ export const defaultTargetConfig: BuildTargetSites = {
 };
 
 export const iOSTargetConfig: BuildTargetSites = {
-  disabledSites: [],
+  disabledSites: [
+    'www.hidive.com',
+    'watch.sling.com',
+  ],
   sites: {
     'play.stan.com.au': [{ mode: 'cue', videoCueLanguage: 'en' }],
   },

--- a/src/script/webAudioSites.ts
+++ b/src/script/webAudioSites.ts
@@ -6,6 +6,11 @@ export const defaultTargetConfig: BuildTargetSites = {
   disabledSites: [],
 };
 
+export const safariTargetConfig: BuildTargetSites = {
+  sites: {},
+  disabledSites: [],
+};
+
 export const supportedSites: AudioSites = {
   'abc.com': [
     { className: 'akamai-caption-text', mode: 'element', tagName: 'DIV' },

--- a/src/script/webConfig.ts
+++ b/src/script/webConfig.ts
@@ -10,7 +10,7 @@ export default class WebConfig extends Config {
   audioWordlistId: number;
   collectStats: boolean;
   contextMenu: boolean;
-  customAudioSites: { [site: string]: AudioRule[] };
+  customAudioSites: AudioSites;
   darkMode: boolean;
   domains: { [site: string]: DomainCfg };
   enabledDomainsOnly: boolean;


### PR DESCRIPTION
## ✨  New Features & Updates:
- 8df3972d720438347bcf6c25f5938a090d694a70 Update audio muting for Stan.com.au (#400)
- Web Audio Site (rules) can now be customized for different deployments (Chrome, Firefox, Safari, iOS, etc.)

## 🐛 Bugs Fixed:
- 815a5fe4eb8c650eeb305db35ff29000d9412b4f Fix for audio muting on YouTube auto-generated captions (Video mute methods)

## 🔧 Development:
- 168d07e3228ea77dafcf4a33ae9493825c9ac19c Re-arrange WebAudio and Sites, add support for build target customizations
- ede07e59bc9fff682cae89101bef885fd0960dc5 Allow Audio Rules to specify a build target